### PR TITLE
1.20.6 support & (Neo)Forge support

### DIFF
--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -38,11 +38,19 @@ preprocess {
 
     // Forge
     Node mc_11701_forge = createNode("better-dev-1.17.1-forge", 1_17_01, "mojang")
+    Node mc_11802_forge = createNode("better-dev-1.18.2-forge", 1_18_02, "mojang")
+    Node mc_11904_forge = createNode("better-dev-1.19.4-forge", 1_19_04, "mojang")
+    Node mc_11206_forge = createNode("better-dev-1.20.6-forge", 1_20_06, "mojang")
 
-    mc_11701_fabric.link(mc_11701_forge, null)
+    mc_11701_fabric.link(mc_11701_forge, file("versions/mapping-1.17.1-fabric-forge.txt"))
+    mc_11802_fabric.link(mc_11802_forge, file("versions/mapping-1.18.2-fabric-forge.txt"))
+    mc_11904_fabric.link(mc_11904_forge, file("versions/mapping-1.19.4-fabric-forge.txt"))
+    mc_12006_fabric.link(mc_11206_forge, file("versions/mapping-1.20.6-fabric-forge.txt"))
 
     // NeoForge
     Node mc_12002_neoforge = createNode("better-dev-1.20.2-neoforge", 1_20_02, "mojang")
+    Node mc_12006_neoforge = createNode("better-dev-1.20.6-neoforge", 1_20_06, "mojang")
 
-    mc_12002_fabric.link(mc_12002_neoforge, null)
+    mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
+    mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
 }

--- a/magiclib-better-dev/src/main/resources/META-INF/neoforge.mods.toml
+++ b/magiclib-better-dev/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,32 @@
+modLoader = "javafml"
+loaderVersion = "*"
+license = "${mod_license}"
+
+[[mods]]
+modId = "${mod_id}"
+version = "${mod_version}"
+displayName = "${mod_name}"
+description = '''
+${mod_description}
+'''
+logoFile = "icon.png"
+authors = "Hendrix-Shen, Plusls"
+displayURL = "${mod_homepage}"
+displayTest = "NONE"
+
+[[dependencies.${mod_id}]]
+modId = "magiclib_core"
+mandatory=true
+versionRange="*"
+ordering="AFTER"
+side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "minecraft"
+mandatory=true
+versionRange="${minecraft_dependency}"
+ordering="AFTER"
+side="BOTH"
+
+[[mixins]]
+config = "magiclib-better-dev.mixins.json"

--- a/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
@@ -85,20 +85,24 @@ def runtimeDependencies = [
 dependencies {
     minecraft("com.mojang:minecraft:${project.property("dependencies.minecraft_version")}")
     mappings(loom.officialMojangMappings())
-    modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
 
     // Lombok
     compileOnly("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
     annotationProcessor("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
 
-    // Make IDE happy.
-    api(project(path: ":magiclib-core:${modPlatform}"))
-    api(project(path: ":magiclib-core:common", configuration: "shadow"))
+    // MagicLib Core
+    api(project(path: ":magiclib-core:${modPlatform}", configuration: "shadow"))
 
-    if (modPlatform == "forge") {
-        forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
-    } else if (modPlatform == "neoforge") {
-        neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+    switch (modPlatform) {
+        case "fabric":
+            modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
+            break
+        case "forge":
+            forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
+            break
+        case "neoforge":
+            neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+            break
     }
 
     // API
@@ -244,7 +248,10 @@ base {
 }
 
 java {
-    if (mcVersion > 11701) {
+    if (mcVersion > 11204) {
+        sourceCompatibility(JavaVersion.VERSION_21)
+        targetCompatibility(JavaVersion.VERSION_21)
+    } else if (mcVersion > 11701) {
         sourceCompatibility(JavaVersion.VERSION_17)
         targetCompatibility(JavaVersion.VERSION_17)
     } else if (mcVersion > 11605) {
@@ -283,9 +290,10 @@ replaceToken {
 
 processResources {
     [
-            "fabric.mod.json"   : ["fabric"],
-            "META-INF"          : ["forge", "neoforge"],
-            "META-INF/mods.toml": ["forge", "neoforge"]
+            "fabric.mod.json"            : ["fabric"],
+            "META-INF"                   : ["forge", "neoforge"],
+            "META-INF/mods.toml"         : ["forge", "neoforge", mcVersion < 12005 ? "neoforge": "none"],
+            "META-INF/neoforge.mods.toml": [mcVersion > 12004 ? "neoforge" : "none"]
     ].forEach { file, platforms ->
         if (platforms.contains(modPlatform)) {
             filesMatching(file) {
@@ -413,7 +421,9 @@ tasks.withType(Javadoc).configureEach { Javadoc task ->
 tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     task.options.encoding("UTF-8")
 
-    if (mcVersion > 11701) {
+    if (mcVersion > 12005) {
+        task.options.release.set(21)
+    } else if (mcVersion > 11701) {
         task.options.release.set(17)
     } else if (mcVersion > 11605) {
         task.options.release.set(16)

--- a/magiclib-better-dev/versions/1.18.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.18.2-fabric/gradle.properties
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=3.2.5
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 8.0.1
-# InGameAccountSwitcher-Fabric-1.18-8.0.2.jar
-dependencies.runtime.inGameAccountSwitcher_version=8.0.2-fabric1.18
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Fabric-1.18.2-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=9.0.0-beta.5
 
 # Publish properties
 publish.game_version=1.18.2

--- a/magiclib-better-dev/versions/1.18.2-forge/gradle.properties
+++ b/magiclib-better-dev/versions/1.18.2-forge/gradle.properties
@@ -1,0 +1,17 @@
+# Dependency Versions
+dependencies.forge_version=40.2.21
+dependencies.minecraft_dependency=1.18.x
+dependencies.minecraft_version=1.18.2
+
+# IMBlocker
+# TODO
+dependencies.runtime.imblocker_version=0
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Forge-1.18.2-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=neEUgZhW
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.18.2

--- a/magiclib-better-dev/versions/1.18.2-forge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.18.2-forge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/1.19.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.2-fabric/gradle.properties
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=4.2.0-beta.2
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 8.0.1
-# InGameAccountSwitcher-Fabric-1.19-8.0.1.jar
-dependencies.runtime.inGameAccountSwitcher_version=8.0.1-fabric1.19
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Fabric-1.19.2-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=aAfFPOkr
 
 # Publish properties
 publish.game_version=1.19.2

--- a/magiclib-better-dev/versions/1.19.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.4-fabric/gradle.properties
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=6.3.1
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 8.0.2
-# InGameAccountSwitcher-Fabric-1.19-8.0.2.jar
-dependencies.runtime.inGameAccountSwitcher_version=8.0.2-fabric1.19
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Fabric-1.19.4-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=pgKLlgI3
 
 # Publish properties
 publish.game_version=1.19.4

--- a/magiclib-better-dev/versions/1.19.4-forge/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.4-forge/gradle.properties
@@ -1,0 +1,17 @@
+# Dependency Versions
+dependencies.forge_version=45.2.15
+dependencies.minecraft_dependency=1.19.4
+dependencies.minecraft_version=1.19.4
+
+# IMBlocker
+# TODO
+dependencies.runtime.imblocker_version=0
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Forge-1.19.4-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=MbsICOf1
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.19.4

--- a/magiclib-better-dev/versions/1.19.4-forge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.19.4-forge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/1.20.1-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.1-fabric/gradle.properties
@@ -2,8 +2,8 @@
 dependencies.minecraft_dependency=1.20.1
 dependencies.minecraft_version=1.20.1
 
-# Fabric API 0.92.0+1.20.1
-dependencies.api.fabric_version=0.92.0+1.20.1
+# Fabric API 0.92.2+1.20.1
+dependencies.api.fabric_version=0.92.2+1.20.1
 # Mod Menu - 7.2.2
 # modmenu-7.2.2.jar
 dependencies.api.modmenu_version=7.2.2
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=7.2.2
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 8.0.2
-# InGameAccountSwitcher-Fabric-1.20-8.0.2.jar
-dependencies.runtime.inGameAccountSwitcher_version=8.0.2-fabric1.20
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Fabric-1.20.1-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=RNcL1dfl
 
 # Publish properties
 publish.game_version=1.20.1

--- a/magiclib-better-dev/versions/1.20.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.2-fabric/gradle.properties
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=8.0.1
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 8.0.2
-# InGameAccountSwitcher-Fabric-1.20.2-8.0.2.jar
-dependencies.runtime.inGameAccountSwitcher_version=8.0.2-fabric1.20.2
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Fabric-1.20.2-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=HIltNGdW
 
 # Publish properties
 publish.game_version=1.20.2

--- a/magiclib-better-dev/versions/1.20.2-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.2-neoforge/gradle.properties
@@ -3,12 +3,12 @@ dependencies.neoforge_version=20.2.88
 dependencies.minecraft_dependency=1.20.2
 dependencies.minecraft_version=1.20.2
 
-# IMBlocker 4.0.8+1.20
+# IMBlocker
 # TODO
 dependencies.runtime.imblocker_version=0
-# In-Game Account Switcher
-# TODO
-dependencies.runtime.inGameAccountSwitcher_version=0
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-NeoForge-1.20.2-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=C2RZfsvv
 
 # Loom Properties
 loom.platform=neoforge

--- a/magiclib-better-dev/versions/1.20.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.4-fabric/gradle.properties
@@ -2,8 +2,8 @@
 dependencies.minecraft_dependency=>=1.20.3- <1.20.5-
 dependencies.minecraft_version=1.20.4
 
-# Fabric API 0.97.0+1.20.4
-dependencies.api.fabric_version=0.97.0+1.20.4
+# Fabric API 0.97.1+1.20.4
+dependencies.api.fabric_version=0.97.1+1.20.4
 # Mod Menu - 9.2.0-beta.2
 # modmenu-9.2.0-beta.2.jar
 dependencies.api.modmenu_version=9.2.0-beta.2
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=9.2.0-beta.2
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 8.0.2
-# InGameAccountSwitcher-Fabric-1.20.4-8.0.2.jar
-dependencies.runtime.inGameAccountSwitcher_version=8.0.2-fabric1.20.4
+# In-Game Account Switcher 1.20.4-9.0.0-beta.5
+# IAS-Fabric-1.20.4-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=UKyXKfEB
 
 # Publish properties
 publish.game_version=1.20.3\n1.20.4

--- a/magiclib-better-dev/versions/1.20.6-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.6-fabric/gradle.properties
@@ -2,18 +2,18 @@
 dependencies.minecraft_dependency=>=1.20.5- <1.20.7-
 dependencies.minecraft_version=1.20.6
 
-# Fabric API 0.97.7+1.20.5
-dependencies.api.fabric_version=0.98.0+1.20.6
-# Mod Menu - 10.0.0-beta.1
+# Fabric API 0.99.4+1.20.6
+dependencies.api.fabric_version=0.99.4+1.20.6
+# Mod Menu 10.0.0-beta.1
 # modmenu-10.0.0-beta.1.jar
 dependencies.api.modmenu_version=10.0.0-beta.1
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
-# In-Game Account Switcher 9.0.0-beta.1
-# IAS-Fabric-1.20.5-9.0.0-beta.1.jar
-dependencies.runtime.inGameAccountSwitcher_version=9.0.0-beta.1
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-Fabric-1.20.6-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=rKSlgsBs
 
 # Publish properties
 publish.game_version=1.20.5\n1.20.6

--- a/magiclib-better-dev/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.6-neoforge/gradle.properties
@@ -1,0 +1,17 @@
+# Dependency Versions
+dependencies.neoforge_version=20.6.100-beta
+dependencies.minecraft_dependency=1.20.6
+dependencies.minecraft_version=1.20.6
+
+# IMBlocker
+# TODO
+dependencies.runtime.imblocker_version=0
+# In-Game Account Switcher 9.0.0-beta.5
+# IAS-NeoForge-1.20.6-9.0.0-beta.5.jar
+dependencies.runtime.inGameAccountSwitcher_version=zdvTBbDU
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.20.6

--- a/magiclib-better-dev/versions/1.20.6-neoforge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.20.6-neoforge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/mapping-1.17.1-fabric-forge.txt
+++ b/magiclib-better-dev/versions/mapping-1.17.1-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-better-dev/versions/mapping-1.18.2-fabric-forge.txt
+++ b/magiclib-better-dev/versions/mapping-1.18.2-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-better-dev/versions/mapping-1.19.4-fabric-forge.txt
+++ b/magiclib-better-dev/versions/mapping-1.19.4-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-better-dev/versions/mapping-1.20.2-fabric-neoforge.txt
+++ b/magiclib-better-dev/versions/mapping-1.20.2-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-better-dev/versions/mapping-1.20.6-fabric-neoforge.txt
+++ b/magiclib-better-dev/versions/mapping-1.20.6-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
@@ -53,12 +53,17 @@ public class SimpleMixinChecker implements MixinDependencyChecker {
 
         AnnotationNode mixinConfigNode = Annotations.getVisible(mixinClassNode, CompositeDependencies.class);
         List<AnnotationNode> nodes = Annotations.getValue(mixinConfigNode, "value", true);
+
+        if (nodes.isEmpty()) {
+            return true;
+        }
+
         List<DependenciesContainer<?>> dependencies = nodes
                 .stream()
                 .map(node -> DependenciesContainer.of(node, targetClassNode))
                 .collect(Collectors.toList());
 
-        if (dependencies.stream().allMatch(DependenciesContainer::isSatisfied)) {
+        if (dependencies.stream().anyMatch(DependenciesContainer::isSatisfied)) {
             return true;
         }
 

--- a/magiclib-core/neoforge/build.gradle
+++ b/magiclib-core/neoforge/build.gradle
@@ -17,7 +17,7 @@ java {
 }
 
 processResources {
-    filesMatching("META-INF/mods.toml") {
+    filesMatching(["META-INF/mods.toml", "META-INF/neoforge.mods.toml"]) {
         expand([
                 "mod_description": project.parent.property("mod.description"),
                 "mod_homepage"   : project.parent.property("mod.homepage"),

--- a/magiclib-core/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/magiclib-core/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,18 @@
+modLoader = "javafml"
+loaderVersion = "*"
+license = "${mod_license}"
+
+[[mods]]
+modId = "${mod_id}"
+version = "${mod_version}"
+displayName = "${mod_name}"
+description = '''
+${mod_description}
+'''
+logoFile = "icon.png"
+authors = "Hendrix-Shen, Plusls"
+displayURL = "${mod_homepage}"
+displayTest = "NONE"
+
+[[mixins]]
+config = "magiclib-core-bootstrap.mixins.json"

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/compat/minecraft/api/world/SimpleContainerCompatApi.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/compat/minecraft/api/world/SimpleContainerCompatApi.java
@@ -4,10 +4,19 @@ import net.minecraft.nbt.ListTag;
 import org.jetbrains.annotations.ApiStatus;
 import top.hendrixshen.magiclib.compat.api.UnImplCompatApiException;
 
+//#if MC > 12004
+//$$ import net.minecraft.core.HolderLookup;
+//#endif
+
 @Deprecated
 @ApiStatus.ScheduledForRemoval
 public interface SimpleContainerCompatApi {
-    default void fromTagCompat(ListTag listTag) {
+    default void fromTagCompat(
+            ListTag listTag
+            //#if MC > 12004
+            //$$ , HolderLookup.Provider provider
+            //#endif
+    ) {
         throw new UnImplCompatApiException();
     }
 }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/compat/minecraft/api/world/level/block/entity/BlockEntityCompatApi.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/compat/minecraft/api/world/level/block/entity/BlockEntityCompatApi.java
@@ -4,16 +4,35 @@ import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.ApiStatus;
 import top.hendrixshen.magiclib.compat.api.UnImplCompatApiException;
 
+//#if MC > 12004
+//$$ import net.minecraft.core.HolderLookup;
+//#endif
+
 @Deprecated
 @ApiStatus.ScheduledForRemoval
 public interface BlockEntityCompatApi {
-    default void loadCompat(CompoundTag compoundTag) {
+    default void loadCompat(
+            CompoundTag compoundTag
+            //#if MC > 12004
+            //$$ , HolderLookup.Provider holder
+            //#endif
+    ) {
         throw new UnImplCompatApiException();
     }
 
     //#if MC > 11502 && MC < 11700
-    default void load(CompoundTag compoundTag) {
-        this.loadCompat(compoundTag);
+    default void load(
+            CompoundTag compoundTag
+            //#if MC > 12004
+            //$$ , HolderLookup.Provider holder
+            //#endif
+    ) {
+        this.loadCompat(
+                compoundTag
+                //#if MC > 12004
+                //$$ , holder
+                //#endif
+        );
     }
     //#endif
 }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/MixinSimpleContainer.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/MixinSimpleContainer.java
@@ -6,6 +6,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import top.hendrixshen.magiclib.compat.minecraft.api.world.SimpleContainerCompatApi;
 
+//#if MC > 12004
+//$$ import net.minecraft.core.HolderLookup;
+//#endif
+
 //#if MC < 11600
 //$$ import net.minecraft.world.item.ItemStack;
 //#endif
@@ -14,7 +18,12 @@ import top.hendrixshen.magiclib.compat.minecraft.api.world.SimpleContainerCompat
 public abstract class MixinSimpleContainer implements SimpleContainerCompatApi {
     //#if MC > 11502
     @Shadow
-    public abstract void fromTag(ListTag listTag);
+    public abstract void fromTag(
+            ListTag listTag
+            //#if MC > 12004
+            //$$ , HolderLookup.Provider provider
+            //#endif
+    );
     //#else
     //$$ @Shadow
     //$$ public abstract ItemStack addItem(ItemStack itemStack);
@@ -22,12 +31,23 @@ public abstract class MixinSimpleContainer implements SimpleContainerCompatApi {
     //#endif
 
     @Override
-    public void fromTagCompat(ListTag listTag) {
+    public void fromTagCompat(
+            ListTag listTag
+            //#if MC > 12004
+            //$$ , HolderLookup.Provider provider
+            //#endif
+    ) {
         //#if MC > 11502
-        this.fromTag(listTag);
+        this.fromTag(
+                listTag
+                //#if MC > 12004
+                //$$ , provider
+                //#endif
+        );
         //#else
         //$$ for (int i = 0; i < listTag.size(); ++i) {
         //$$     ItemStack itemStack = ItemStack.of(listTag.getCompound(i));
+        //$$
         //$$     if (!itemStack.isEmpty()) {
         //$$         this.addItem(itemStack);
         //$$     }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/entity/MixinEntity.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/entity/MixinEntity.java
@@ -19,7 +19,10 @@ import java.util.UUID;
 
 @Mixin(Entity.class)
 public abstract class MixinEntity implements EntityCompatApi {
-    //#if MC > 11903
+    //#if MC > 12004
+    //$$ @Shadow
+    //$$ public abstract float maxUpStep();
+    //#elseif MC > 11903
     //$$ @Shadow
     //$$ private float maxUpStep;
     //$$
@@ -217,12 +220,18 @@ public abstract class MixinEntity implements EntityCompatApi {
 
     @Override
     public float maxUpStepCompat() {
+        //#if MC > 12004
+        //$$ return this.maxUpStep();
+        //#else
         return this.maxUpStep;
+        //#endif
     }
 
     @Override
     public void setMaxUpStepCompat(float maxUpStep) {
-        //#if MC > 11903
+        //#if MC > 12004
+        //$$ throw new UnsupportedOperationException();
+        //#elseif MC > 11903
         //$$ this.setMaxUpStep(maxUpStep);
         //#else
         this.maxUpStep = maxUpStep;

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/level/block/entity/MixinBlockEntity.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/level/block/entity/MixinBlockEntity.java
@@ -1,11 +1,14 @@
 package top.hendrixshen.magiclib.mixin.compat.minecraft.world.level.block.entity;
 
-
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import top.hendrixshen.magiclib.compat.minecraft.api.world.level.block.entity.BlockEntityCompatApi;
+
+//#if MC > 12004
+//$$ import net.minecraft.core.HolderLookup;
+//#endif
 
 //#if MC > 11502 && MC < 11700
 import net.minecraft.core.BlockPos;
@@ -15,11 +18,13 @@ import net.minecraft.world.level.block.state.BlockState;
 
 @Mixin(BlockEntity.class)
 public abstract class MixinBlockEntity implements BlockEntityCompatApi {
-    //#if MC > 11605 || MC < 11600
+    //#if MC > 12004
+    //$$ @Shadow
+    //$$ public abstract void loadWithComponents(CompoundTag compoundTag, HolderLookup.Provider provider);
+    //#elseif MC > 11605 || MC < 11600
     //$$ @Shadow
     //$$ public abstract void load(CompoundTag compoundTag);
     //#else
-
     @Shadow
     public abstract void load(BlockState blockState, CompoundTag compoundTag);
 
@@ -28,12 +33,18 @@ public abstract class MixinBlockEntity implements BlockEntityCompatApi {
 
     @Shadow
     public abstract BlockPos getBlockPos();
-
     //#endif
 
     @Override
-    public void loadCompat(CompoundTag compoundTag) {
-        //#if MC > 11605 || MC <= 11502
+    public void loadCompat(
+            CompoundTag compoundTag
+            //#if MC > 12004
+            //$$ , HolderLookup.Provider provider
+            //#endif
+    ) {
+        //#if MC > 11204
+        //$$ this.loadWithComponents(compoundTag, provider);
+        //#elseif MC > 11605 || MC <= 11502
         //$$ this.load(compoundTag);
         //#else
         this.load(this.getLevel().getBlockState(this.getBlockPos()), compoundTag);

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/level/block/entity/MixinBlockEntity.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/world/level/block/entity/MixinBlockEntity.java
@@ -42,7 +42,7 @@ public abstract class MixinBlockEntity implements BlockEntityCompatApi {
             //$$ , HolderLookup.Provider provider
             //#endif
     ) {
-        //#if MC > 11204
+        //#if MC > 12004
         //$$ this.loadWithComponents(compoundTag, provider);
         //#elseif MC > 11605 || MC <= 11502
         //$$ this.load(compoundTag);

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/event/render/MixinLevelRenderer.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/event/render/MixinLevelRenderer.java
@@ -38,8 +38,31 @@ public class MixinLevelRenderer {
                     //#endif
             )
     )
-    private void postRenderLevelNormal(PoseStack poseStack, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, CallbackInfo ci) {
-        RenderEventHandler.getInstance().dispatchPostRenderLevelEvent(this.level, poseStack, tickDelta);
+    private void postRenderLevelNormal(
+            //#if MC < 12005
+            PoseStack poseStack,
+            //#endif
+            float tickDelta,
+            long limitTime,
+            boolean renderBlockOutline,
+            Camera camera,
+            GameRenderer gameRenderer,
+            LightTexture lightTexture,
+            Matrix4f matrix4f,
+            //#if MC > 12004
+            //$$ Matrix4f matrix4f2,
+            //#endif
+            CallbackInfo ci
+    ) {
+        RenderEventHandler.getInstance().dispatchPostRenderLevelEvent(
+                this.level,
+                //#if MC > 12004
+                //$$ new PoseStack(),
+                //#elseif MC > 11502
+                poseStack,
+                //#endif
+                tickDelta
+        );
     }
 
     //#if MC > 11502
@@ -62,8 +85,31 @@ public class MixinLevelRenderer {
                     target = "Lnet/minecraft/client/renderer/PostChain;process(F)V"
             )
     )
-    private void postRenderLevelFabulous(PoseStack poseStack, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, CallbackInfo ci) {
-        RenderEventHandler.getInstance().dispatchPostRenderLevelEvent(this.level, poseStack, tickDelta);
+    private void postRenderLevelFabulous(
+            //#if MC < 12005
+            PoseStack poseStack,
+            //#endif
+            float tickDelta,
+            long limitTime,
+            boolean renderBlockOutline,
+            Camera camera,
+            GameRenderer gameRenderer,
+            LightTexture lightTexture,
+            Matrix4f matrix4f,
+            //#if MC > 12004
+            //$$ Matrix4f matrix4f2,
+            //#endif
+            CallbackInfo ci
+    ) {
+        RenderEventHandler.getInstance().dispatchPostRenderLevelEvent(
+                this.level,
+                //#if MC > 12004
+                //$$ new PoseStack(),
+                //#elseif MC > 11502
+                poseStack,
+                //#endif
+                tickDelta
+        );
     }
     //#endif
 }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/event/render/MixinLevelRenderer.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/event/render/MixinLevelRenderer.java
@@ -58,7 +58,7 @@ public class MixinLevelRenderer {
                 this.level,
                 //#if MC > 12004
                 //$$ new PoseStack(),
-                //#elseif MC > 11502
+                //#else
                 poseStack,
                 //#endif
                 tickDelta
@@ -105,7 +105,7 @@ public class MixinLevelRenderer {
                 this.level,
                 //#if MC > 12004
                 //$$ new PoseStack(),
-                //#elseif MC > 11502
+                //#else
                 poseStack,
                 //#endif
                 tickDelta

--- a/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
@@ -89,15 +89,13 @@ def runtimeDependencies = [
 dependencies {
     minecraft("com.mojang:minecraft:${project.property("dependencies.minecraft_version")}")
     mappings(loom.officialMojangMappings())
-    modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
 
     // Lombok
     compileOnly("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
     annotationProcessor("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
 
-    // Make IDE happy.
-    api(project(path: ":magiclib-core:${modPlatform}"))
-    api(project(path: ":magiclib-core:common", configuration: "shadow"))
+    // MagicLib Core
+    api(project(path: ":magiclib-core:${modPlatform}", configuration: "shadow"))
 
     api(project(path: betterDev.path, configuration: "namedElements"))
     api(project(path: malilib.path, configuration: "namedElements"))
@@ -108,10 +106,16 @@ dependencies {
         localRuntime(project(path: betterDev.path, configuration: "modRuntimeClasspathMainMapped"))
     }
 
-    if (modPlatform == "forge") {
-        forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
-    } else if (modPlatform == "neoforge") {
-        neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+    switch (modPlatform) {
+        case "fabric":
+            modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
+            break
+        case "forge":
+            forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
+            break
+        case "neoforge":
+            neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+            break
     }
 
     // API
@@ -294,9 +298,10 @@ replaceToken {
 
 processResources {
     [
-            "fabric.mod.json"   : ["fabric"],
-            "META-INF"          : ["forge", "neoforge"],
-            "META-INF/mods.toml": ["forge", "neoforge"]
+            "fabric.mod.json"            : ["fabric"],
+            "META-INF"                   : ["forge", "neoforge"],
+            "META-INF/mods.toml"         : ["forge", "neoforge", mcVersion < 12005 ? "neoforge": "none"],
+            "META-INF/neoforge.mods.toml": [mcVersion > 12004 ? "neoforge" : "none"]
     ].forEach { file, platforms ->
         if (platforms.contains(modPlatform)) {
             filesMatching(file) {

--- a/magiclib-legacy-compat/versions/1.20.4-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.20.4-fabric/gradle.properties
@@ -2,7 +2,7 @@
 dependencies.minecraft_dependency=>=1.20.3- <1.20.5-
 dependencies.minecraft_version=1.20.4
 
-# Carpet - 1.20.3-1.4.128+v231205
+# Carpet - 1.4.128+v231205
 # fabric-carpet-1.20.3-1.4.128+v231205.jar
 dependencies.api.carpet_version=1.20.3-1.4.128+v231205
 

--- a/magiclib-legacy-compat/versions/1.20.6-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.20.6-fabric/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.20.5- <1.20.7-
+dependencies.minecraft_version=1.20.6
+
+# Carpet - 1.4.141+v240429
+# fabric-carpet-1.20.6-1.4.141+v240429.jar
+dependencies.api.carpet_version=1.20.6-1.4.141+v240429
+
+# Publish properties
+publish.game_version=1.20.5\n1.20.6

--- a/magiclib-legacy-compat/versions/1.20.6-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
+++ b/magiclib-legacy-compat/versions/1.20.6-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/build.gradle
+++ b/magiclib-malilib-extra/build.gradle
@@ -22,6 +22,7 @@ preprocess {
     Node mc_12001_fabric = createNode("malilib-1.20.1-fabric", 1_20_01, "mojang")
     Node mc_12002_fabric = createNode("malilib-1.20.2-fabric", 1_20_02, "mojang")
     Node mc_12004_fabric = createNode("malilib-1.20.4-fabric", 1_20_04, "mojang")
+    Node mc_12006_fabric = createNode("malilib-1.20.6-fabric", 1_20_06, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, null)
@@ -33,9 +34,19 @@ preprocess {
     mc_11904_fabric.link(mc_12001_fabric, null)
     mc_12001_fabric.link(mc_12002_fabric, null)
     mc_12002_fabric.link(mc_12004_fabric, null)
+    mc_12004_fabric.link(mc_12006_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("malilib-1.17.1-forge", 1_17_01, "mojang")
+    Node mc_11802_forge = createNode("malilib-1.18.2-forge", 1_18_02, "mojang")
+    Node mc_11804_forge = createNode("malilib-1.19.4-forge", 1_19_04, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, null)
+    mc_11802_fabric.link(mc_11802_forge, null)
+    mc_11904_fabric.link(mc_11804_forge, null)
+
+    // NeoForge
+    Node mc_12006_neoforge = createNode("malilib-1.20.6-neoforge", 1_20_06, "mojang")
+
+    mc_12006_fabric.link(mc_12006_neoforge, null)
 }

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
@@ -7,7 +7,11 @@ import fi.dy.masa.malilib.hotkeys.IKeybindProvider;
 import top.hendrixshen.magiclib.impl.malilib.SharedConstants;
 
 //#if FORGE_LIKE
+//#if MC > 11701
+//$$ import org.thinkingstudio.mafglib.util.ForgePlatformUtils;
+//#else
 //$$ import fi.dy.masa.malilib.compat.forge.ForgePlatformCompat;
+//#endif
 //#endif
 
 public class MalilibStuffsInitializer {
@@ -26,11 +30,20 @@ public class MalilibStuffsInitializer {
 
     //#if FORGE_LIKE
     //$$ private static void setupForgeConfigGui() {
+    //#if MC > 11701
+    //$$     ForgePlatformUtils.getInstance().registerModConfigScreen(SharedConstants.getModIdentifier(),
+    //#else
     //$$     ForgePlatformCompat.getInstance()
-    //$$             .getMod(SharedConstants.getModIdentifier())
-    //$$             .registerModConfigScreen(screen -> {
+    //$$         .getMod(SharedConstants.getModIdentifier())
+    //$$         .registerModConfigScreen(
+    //#endif
+    //$$             screen -> {
     //$$                 ConfigGui gui = new ConfigGui();
+    //#if MC > 11903
+    //$$                 gui.setParent(screen);
+    //#else
     //$$                 gui.setParentGui(screen);
+    //#endif
     //$$                 return gui;
     //$$             });
     //$$ }

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
@@ -7,7 +7,7 @@ import fi.dy.masa.malilib.hotkeys.IKeybindProvider;
 import top.hendrixshen.magiclib.impl.malilib.SharedConstants;
 
 //#if FORGE_LIKE
-//#if MC > 11701
+//#if MC > 11701 && MC != 11904
 //$$ import org.thinkingstudio.mafglib.util.ForgePlatformUtils;
 //#else
 //$$ import fi.dy.masa.malilib.compat.forge.ForgePlatformCompat;
@@ -30,7 +30,7 @@ public class MalilibStuffsInitializer {
 
     //#if FORGE_LIKE
     //$$ private static void setupForgeConfigGui() {
-    //#if MC > 11701
+    //#if MC > 11701 && MC != 11904
     //$$     ForgePlatformUtils.getInstance().registerModConfigScreen(SharedConstants.getModIdentifier(),
     //#else
     //$$     ForgePlatformCompat.getInstance()

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
@@ -15,7 +15,7 @@ import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
 
-@CompositeDependencies(
+@CompositeDependencies({
         @Dependencies(
                 require = {
                         @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib"),
@@ -23,8 +23,16 @@ import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
                         @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class),
 
                 }
+        ),
+        @Dependencies(
+                require = {
+                        @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib"),
+                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
+                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class),
+
+                }
         )
-)
+})
 @Mixin(value = GuiTextFieldGeneric.class, remap = false)
 public class GuiTextFieldGenericMixin extends EditBox {
     @Unique

--- a/magiclib-malilib-extra/src/main/resources/META-INF/neoforge.mods.toml
+++ b/magiclib-malilib-extra/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,39 @@
+modLoader = "javafml"
+loaderVersion = "*"
+license = "${mod_license}"
+
+[[mods]]
+modId = "${mod_id}"
+version = "${mod_version}"
+displayName = "${mod_name}"
+description = '''
+${mod_description}
+'''
+logoFile = "icon.png"
+authors = "Hendrix-Shen, Plusls"
+displayURL = "${mod_homepage}"
+displayTest = "NONE"
+
+[[dependencies.${mod_id}]]
+modId = "magiclib_minecraft_api"
+mandatory=true
+versionRange="*"
+ordering="AFTER"
+side="CLIENT"
+
+[[dependencies.${mod_id}]]
+modId = "${malilib_mod_id}"
+mandatory=true
+versionRange="*"
+ordering="AFTER"
+side="CLIENT"
+
+[[dependencies.${mod_id}]]
+modId = "minecraft"
+mandatory=true
+versionRange="${minecraft_dependency}"
+ordering="NONE"
+side="CLIENT"
+
+[[mixins]]
+config = "magiclib-malilib-extra.mixins.json"

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -64,7 +64,7 @@ repositories {
         url("https://jitpack.io")
 
         content {
-            includeGroup("com.github.Nyan-Work")
+            includeGroup("com.github.sakura-ryoko")
         }
     }
 
@@ -73,8 +73,9 @@ repositories {
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def apiDependencies = [
-        ["maven.modrinth:malilib", "malilib", fabricLike, false],
-        ["maven.modrinth:mafglib", "malilib", forgeLike , false],
+        ["maven.modrinth:malilib"         , "malilib", fabricLike && mcVersion < 12005, false],
+        ["com.github.sakura-ryoko:malilib", "malilib", fabricLike && mcVersion > 12004, false],
+        ["maven.modrinth:mafglib"         , "malilib", forgeLike                      , false],
 ]
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
@@ -84,15 +85,13 @@ def runtimeDependencies = [
 dependencies {
     minecraft("com.mojang:minecraft:${project.property("dependencies.minecraft_version")}")
     mappings(loom.officialMojangMappings())
-    modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
 
     // Lombok
     compileOnly("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
     annotationProcessor("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
 
-    // Make IDE happy.
-    api(project(path: ":magiclib-core:${modPlatform}"))
-    api(project(path: ":magiclib-core:common", configuration: "shadow"))
+    // MagicLib Core
+    api(project(path: ":magiclib-core:${modPlatform}", configuration: "shadow"))
 
     // MC-API
     api(project(path: mcAPI.path, configuration: "namedElements"))
@@ -106,10 +105,16 @@ dependencies {
         localRuntime(project(path: betterDev.path, configuration: "modRuntimeClasspathMainMapped"))
     }
 
-    if (modPlatform == "forge") {
-        forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
-    } else if (modPlatform == "neoforge") {
-        neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+    switch (modPlatform) {
+        case "fabric":
+            modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
+            break
+        case "forge":
+            forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
+            break
+        case "neoforge":
+            neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+            break
     }
 
     // API
@@ -255,7 +260,10 @@ base {
 }
 
 java {
-    if (mcVersion > 11701) {
+    if (mcVersion > 12004) {
+        sourceCompatibility(JavaVersion.VERSION_21)
+        targetCompatibility(JavaVersion.VERSION_21)
+    } else if (mcVersion > 11701) {
         sourceCompatibility(JavaVersion.VERSION_17)
         targetCompatibility(JavaVersion.VERSION_17)
     } else if (mcVersion > 11605) {
@@ -294,9 +302,10 @@ replaceToken {
 
 processResources {
     [
-            "fabric.mod.json"   : ["fabric"],
-            "META-INF"          : ["forge", "neoforge"],
-            "META-INF/mods.toml": ["forge", "neoforge"]
+            "fabric.mod.json"            : ["fabric"],
+            "META-INF"                   : ["forge", "neoforge"],
+            "META-INF/mods.toml"         : ["forge", "neoforge", mcVersion < 12005 ? "neoforge": "none"],
+            "META-INF/neoforge.mods.toml": [mcVersion > 12004 ? "neoforge" : "none"]
     ].forEach { file, platforms ->
         if (platforms.contains(modPlatform)) {
             filesMatching(file) {
@@ -425,7 +434,9 @@ tasks.withType(Javadoc).configureEach { Javadoc task ->
 tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     task.options.encoding("UTF-8")
 
-    if (mcVersion > 11701) {
+    if (mcVersion > 12004) {
+        task.options.release.set(21)
+    } else if (mcVersion > 11701) {
         task.options.release.set(17)
     } else if (mcVersion > 11605) {
         task.options.release.set(16)

--- a/magiclib-malilib-extra/versions/1.18.2-forge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.18.2-forge/gradle.properties
@@ -1,0 +1,14 @@
+# Dependency Versions
+dependencies.forge_version=40.2.21
+dependencies.minecraft_dependency=1.18.x
+dependencies.minecraft_version=1.18.2
+
+# Malilib 0.1.12
+# MaFgLib-0.1.12-mc1.18.2.jar
+dependencies.api.malilib_version=0.1.12-mc1.18.2
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.18.2

--- a/magiclib-malilib-extra/versions/1.18.2-forge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.18.2-forge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/1.19.4-forge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.19.4-forge/gradle.properties
@@ -1,0 +1,14 @@
+# Dependency Versions
+dependencies.forge_version=45.2.15
+dependencies.minecraft_dependency=1.19.4
+dependencies.minecraft_version=1.19.4
+
+# Malilib 0.1.11
+# MaFgLib-0.1.11-mc1.19.4.jar
+dependencies.api.malilib_version=0.1.11-mc1.19.4
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.18.2

--- a/magiclib-malilib-extra/versions/1.19.4-forge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.19.4-forge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/1.20.6-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.6-fabric/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.20.5- <1.20.7-
+dependencies.minecraft_version=1.20.6
+
+# Malilib 0.18.999-sakura.4
+# malilib-a2c5251ea2.jar
+dependencies.api.malilib_version=a2c5251ea2
+
+# Publish properties
+publish.game_version=1.20.5\n1.20.6

--- a/magiclib-malilib-extra/versions/1.20.6-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.20.6-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
@@ -1,0 +1,14 @@
+# Dependency Versions
+dependencies.neoforge_version=20.6.100-beta
+dependencies.minecraft_dependency=1.20.6
+dependencies.minecraft_version=1.20.6
+
+# Malilib 0.1.7
+# MaFgLib-0.1.7-mc1.20.6.jar
+dependencies.api.malilib_version=0.1.7-mc1.20.6
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.20.6

--- a/magiclib-malilib-extra/versions/1.20.6-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.20.6-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -38,11 +38,17 @@ preprocess {
 
     // Forge
     Node mc_11701_forge = createNode("mc-api-1.17.1-forge", 1_17_01, "mojang")
+    Node mc_11802_forge = createNode("mc-api-1.18.2-forge", 1_18_02, "mojang")
+    Node mc_11904_forge = createNode("mc-api-1.19.4-forge", 1_19_04, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, file("versions/mapping-1.17.1-fabric-forge.txt"))
+    mc_11802_fabric.link(mc_11802_forge, file("versions/mapping-1.18.2-fabric-forge.txt"))
+    mc_11904_fabric.link(mc_11904_forge, file("versions/mapping-1.19.4-fabric-forge.txt"))
 
     // NeoForge
     Node mc_12002_neoforge = createNode("mc-api-1.20.2-neoforge", 1_20_02, "mojang")
+    Node mc_12006_neoforge = createNode("mc-api-1.20.6-neoforge", 1_20_06, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
+    mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/world/level/block/BlockEntityCompatImpl.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/world/level/block/BlockEntityCompatImpl.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import top.hendrixshen.magiclib.api.compat.AbstractCompat;
 import top.hendrixshen.magiclib.api.compat.minecraft.world.level.block.BlockEntityCompat;
 
+import java.util.Objects;
+
 //#if MC > 12004
 //$$ import net.minecraft.core.HolderLookup;
 //#endif
@@ -27,7 +29,9 @@ public class BlockEntityCompatImpl extends AbstractCompat<BlockEntity> implement
         //#elseif MC > 11605 || MC < 11600
         //$$ this.get().load(compoundTag);
         //#else
-        this.get().load(this.get().getLevel().getBlockState(this.get().getBlockPos()), compoundTag);
+        BlockEntity blockEntity = this.get();
+        blockEntity.load(Objects.requireNonNull(blockEntity.getLevel())
+                .getBlockState(this.get().getBlockPos()), compoundTag);
         //#endif
     }
 }

--- a/magiclib-minecraft-api/src/main/resources/META-INF/neoforge.mods.toml
+++ b/magiclib-minecraft-api/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,32 @@
+modLoader = "javafml"
+loaderVersion = "*"
+license = "${mod_license}"
+
+[[mods]]
+modId = "${mod_id}"
+version = "${mod_version}"
+displayName = "${mod_name}"
+description = '''
+${mod_description}
+'''
+logoFile = "icon.png"
+authors = "Hendrix-Shen, Plusls"
+displayURL = "${mod_homepage}"
+displayTest = "NONE"
+
+[[dependencies.${mod_id}]]
+modId = "magiclib_core"
+mandatory=true
+versionRange="*"
+ordering="AFTER"
+side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "minecraft"
+mandatory=true
+versionRange="${minecraft_dependency}"
+ordering="NONE"
+side="BOTH"
+
+[[mixins]]
+config = "magiclib-minecraft-api.mixins.json"

--- a/magiclib-minecraft-api/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-minecraft-api/versions/1.14.4-fabric/build.gradle
@@ -73,15 +73,13 @@ repositories {
 dependencies {
     minecraft("com.mojang:minecraft:${project.property("dependencies.minecraft_version")}")
     mappings(loom.officialMojangMappings())
-    modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
 
     // Lombok
     compileOnly("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
     annotationProcessor("org.projectlombok:lombok:${project.property("dependencies.lombok_version")}")
 
-    // Make IDE happy.
-    api(project(path: ":magiclib-core:${modPlatform}"))
-    api(project(path: ":magiclib-core:common", configuration: "shadow"))
+    // MagicLib Core
+    api(project(path: ":magiclib-core:${modPlatform}", configuration: "shadow"))
 
     // Dont publish better dev dependencies.
     compileOnly(project(path: betterDev.path, configuration: "namedElements"))
@@ -92,10 +90,16 @@ dependencies {
         localRuntime(project(path: betterDev.path, configuration: "modRuntimeClasspathMainMapped"))
     }
 
-    if (modPlatform == "forge") {
-        forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
-    } else if (modPlatform == "neoforge") {
-        neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+    switch (modPlatform) {
+        case "fabric":
+            modApi("net.fabricmc:fabric-loader:${project.property("dependencies.fabric_loader_version")}")
+            break
+        case "forge":
+            forge("net.minecraftforge:forge:${project.property("dependencies.minecraft_version")}-${project.property("dependencies.forge_version")}")
+            break
+        case "neoforge":
+            neoForge("net.neoforged:neoforge:${project.property("dependencies.neoforge_version")}")
+            break
     }
 }
 
@@ -213,7 +217,10 @@ base {
 }
 
 java {
-    if (mcVersion > 11701) {
+    if (mcVersion > 12004) {
+        sourceCompatibility(JavaVersion.VERSION_21)
+        targetCompatibility(JavaVersion.VERSION_21)
+    } else if (mcVersion > 11701) {
         sourceCompatibility(JavaVersion.VERSION_17)
         targetCompatibility(JavaVersion.VERSION_17)
     } else if (mcVersion > 11605) {
@@ -252,9 +259,10 @@ replaceToken {
 
 processResources {
     [
-            "fabric.mod.json"   : ["fabric"],
-            "META-INF"          : ["forge", "neoforge"],
-            "META-INF/mods.toml": ["forge", "neoforge"]
+            "fabric.mod.json"            : ["fabric"],
+            "META-INF"                   : ["forge", "neoforge"],
+            "META-INF/mods.toml"         : ["forge", "neoforge", mcVersion < 12005 ? "neoforge": "none"],
+            "META-INF/neoforge.mods.toml": [mcVersion > 12004 ? "neoforge" : "none"]
     ].forEach { file, platforms ->
         if (platforms.contains(modPlatform)) {
             filesMatching(file) {
@@ -382,7 +390,9 @@ tasks.withType(Javadoc).configureEach { Javadoc task ->
 tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     task.options.encoding("UTF-8")
 
-    if (mcVersion > 11701) {
+    if (mcVersion > 12004) {
+        task.options.release.set(21)
+    } else if (mcVersion > 11701) {
         task.options.release.set(17)
     } else if (mcVersion > 11605) {
         task.options.release.set(16)

--- a/magiclib-minecraft-api/versions/1.18.2-forge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.18.2-forge/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.forge_version=40.2.21
+dependencies.minecraft_dependency=1.18.x
+dependencies.minecraft_version=1.18.2
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.18.2

--- a/magiclib-minecraft-api/versions/1.18.2-forge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.18.2-forge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible method net/minecraft/client/gui/screens/Screen addRenderableWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;
+accessible method net/minecraft/client/gui/screens/Screen addWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;

--- a/magiclib-minecraft-api/versions/1.19.4-forge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.19.4-forge/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.forge_version=45.2.15
+dependencies.minecraft_dependency=1.19.4
+dependencies.minecraft_version=1.19.4
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.19.4

--- a/magiclib-minecraft-api/versions/1.19.4-forge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.19.4-forge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible method net/minecraft/client/gui/screens/Screen addRenderableWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;
+accessible method net/minecraft/client/gui/screens/Screen addWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;

--- a/magiclib-minecraft-api/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.20.6-neoforge/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.neoforge_version=20.6.100-beta
+dependencies.minecraft_dependency=1.20.6
+dependencies.minecraft_version=1.20.6
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.20.2

--- a/magiclib-minecraft-api/versions/1.20.6-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.20.6-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/mapping-1.18.2-fabric-forge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.18.2-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-minecraft-api/versions/mapping-1.19.4-fabric-forge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.19.4-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-minecraft-api/versions/mapping-1.20.6-fabric-neoforge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.20.6-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/settings.json
+++ b/settings.json
@@ -37,7 +37,8 @@
         "1.19.4-fabric",
         "1.20.1-fabric",
         "1.20.2-fabric",
-        "1.20.4-fabric"
+        "1.20.4-fabric",
+        "1.20.6-fabric"
       ]
     },
     "magiclib-malilib-extra": {

--- a/settings.json
+++ b/settings.json
@@ -17,8 +17,11 @@
         "1.20.6-fabric",
 
         "1.17.1-forge",
+        "1.18.2-forge",
+        "1.19.4-forge",
 
-        "1.20.2-neoforge"
+        "1.20.2-neoforge",
+        "1.20.6-neoforge"
       ]
     },
     "magiclib-legacy-compat": {
@@ -51,8 +54,13 @@
         "1.20.1-fabric",
         "1.20.2-fabric",
         "1.20.4-fabric",
+        "1.20.6-fabric",
 
-        "1.17.1-forge"
+        "1.17.1-forge",
+        "1.18.2-forge",
+        "1.19.4-forge",
+
+        "1.20.6-neoforge"
       ]
     },
     "magiclib-minecraft-api": {
@@ -72,8 +80,11 @@
         "1.20.6-fabric",
 
         "1.17.1-forge",
+        "1.18.2-forge",
+        "1.19.4-forge",
 
-        "1.20.2-neoforge"
+        "1.20.2-neoforge",
+        "1.20.6-neoforge"
       ]
     }
   }


### PR DESCRIPTION
## Features

- [X] NeoForge:  `better-dev`, `mc-api`, `malilib-extra`[^1] for MC 1.20.6
- [X] Forge: `better-dev`, `mc-api`, `malilib-extra`[^1] for MC 1.18.2, 1.19.4, ~1.20.6~ [^2]
- [x] Fabric: `legacy-compat` for MC 1.20.6

[^1]: malilib uses sakura-ryoko port.
[^2]: `architectury-loom` does not yet support 1.20.6 mojmap.