### PR TITLE
Simplified nested annotation usage 

### DIFF
--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/auth/MinecraftMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/auth/MinecraftMixin.java
@@ -28,7 +28,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Coerce;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -36,14 +35,7 @@ import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
 /**
  * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/10e1a937aadcefb1f2d9d9bab8badc873d4a5b3d/versions/1.16.5/src/main/java/me/fallenbreath/tweakermore/mixins/util/qol/MinecraftClientMixin.java">TweakerMore<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.AuthVerifyPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.AuthVerifyPredicate.class))
 @Environment(EnvType.CLIENT)
 @Mixin(Minecraft.class)
 public class MinecraftMixin {

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/chunk/MinecraftServerMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/chunk/MinecraftServerMixin.java
@@ -26,7 +26,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -34,14 +33,7 @@ import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
 /**
  * Reference to <a href="https://github.com/magistermaks/mod-fungible/blob/9cd81f1d8ebcef43cff3df279aaef9bb68950e7c/src/main/java/net/darktree/fungible/mixin/chunk_loading/MinecraftServerMixin.java">Fungible<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.ChunkPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.ChunkPredicate.class))
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
     @Inject(

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/destroy/DataFixerUpperMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/destroy/DataFixerUpperMixin.java
@@ -27,7 +27,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -35,14 +34,7 @@ import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
 /**
  * Reference to <a href="https://github.com/magistermaks/mod-fungible/blob/9cd81f1d8ebcef43cff3df279aaef9bb68950e7c/src/main/java/net/darktree/fungible/mixin/dfu/DatafixTypesMixin.java">Fungible<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.DestroyDFUPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.DestroyDFUPredicate.class))
 @Mixin(value = DataFixerUpper.class, remap = false)
 public class DataFixerUpperMixin {
     @Inject(

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/destroy/SchemaMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/destroy/SchemaMixin.java
@@ -9,19 +9,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
 
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.DestroyDFUPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.DestroyDFUPredicate.class))
 @Mixin(value = Schema.class, remap = false)
 public class SchemaMixin {
     @Inject(

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/DataFixersMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/DataFixersMixin.java
@@ -31,7 +31,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -40,14 +39,7 @@ import top.hendrixshen.magiclib.impl.dev.dfu.lazy.LazyDataFixerBuilder;
 /**
  * Reference to <a href="https://github.com/astei/lazydfu/blob/385764a6fb4cf57b7a39e0ff367a704f74f12497/src/main/java/me/steinborn/lazydfu/mixin/SchemasMixin.java">LazyDFU</a>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.LazyDFUPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.LazyDFUPredicate.class))
 @Mixin(value = DataFixers.class, remap = false)
 public class DataFixersMixin {
     @Redirect(

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/ClientMainMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/ClientMainMixin.java
@@ -32,7 +32,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -41,14 +40,7 @@ import top.hendrixshen.magiclib.impl.dev.threadtweak.ThreadTweaker;
 /**
  * Reference to <a href="https://github.com/UltimateBoomer/mc-smoothboot/blob/9a519ade89af24aa8b337dfed7d8eb8c0b62ec81/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/MainMixin.java">SmoothBoot<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.TheadTweakPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.TheadTweakPredicate.class))
 @Environment(EnvType.CLIENT)
 @Mixin(Main.class)
 public class ClientMainMixin {

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/IntegratedServerMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/IntegratedServerMixin.java
@@ -34,7 +34,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -66,14 +65,7 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 /**
  * Reference to <a href="https://github.com/UltimateBoomer/mc-smoothboot/blob/9a519ade89af24aa8b337dfed7d8eb8c0b62ec81/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/IntegratedServerMixin.java">SmoothBoot<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.TheadTweakPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.TheadTweakPredicate.class))
 @Environment(EnvType.CLIENT)
 @Mixin(IntegratedServer.class)
 public class IntegratedServerMixin {

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/MinecraftServerMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/MinecraftServerMixin.java
@@ -29,7 +29,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -44,14 +43,7 @@ import net.minecraft.server.Main;
 /**
  * Reference to <a href="https://github.com/UltimateBoomer/mc-smoothboot/blob/9a519ade89af24aa8b337dfed7d8eb8c0b62ec81/src/main/java/io/github/ultimateboomer/smoothboot/mixin/server/MainMixin.java">SmoothBoot<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.TheadTweakPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.TheadTweakPredicate.class))
 @Mixin(
         //#if MC > 11502
         Main.class

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/UtilMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/UtilMixin.java
@@ -31,7 +31,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.MagicLib;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -43,14 +42,7 @@ import java.util.concurrent.ExecutorService;
 /**
  * Reference to <a href="https://github.com/UltimateBoomer/mc-smoothboot/blob/9a519ade89af24aa8b337dfed7d8eb8c0b62ec81/src/main/java/io/github/ultimateboomer/smoothboot/mixin/UtilMixin.java">SmoothBoot<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.TheadTweakPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.TheadTweakPredicate.class))
 @Mixin(Util.class)
 public class UtilMixin {
     //#if MC > 11502

--- a/magiclib-better-dev/versions/1.19.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/SharedConstantsMixin.java
+++ b/magiclib-better-dev/versions/1.19.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/SharedConstantsMixin.java
@@ -31,7 +31,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -39,14 +38,7 @@ import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
 /**
  * Reference to <a href="https://github.com/astei/lazydfu/blob/a83ce2f3e7deb429d48134700424b4454f3bee8b/src/main/java/me/steinborn/lazydfu/mixin/SharedConstantsMixin.java">LazyDFU<a/>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.LazyDFUPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.LazyDFUPredicate.class))
 @Mixin(SharedConstants.class)
 public class SharedConstantsMixin {
     @Inject(

--- a/magiclib-better-dev/versions/1.19.3-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/auth/AccountProfileKeyPairManagerMixin.java
+++ b/magiclib-better-dev/versions/1.19.3-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/auth/AccountProfileKeyPairManagerMixin.java
@@ -28,7 +28,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
@@ -39,14 +38,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Reference to <a href="https://github.com/magistermaks/mod-fungible/blob/9cd81f1d8ebcef43cff3df279aaef9bb68950e7c/src/main/java/net/darktree/fungible/mixin/auth/ProfileKeysImplMixin.java">mod-fungible</a>
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.PREDICATE,
-                        predicate = MixinPredicates.AuthEmptyKeyPredicate.class
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.AuthEmptyKeyPredicate.class))
 @Environment(EnvType.CLIENT)
 @Mixin(AccountProfileKeyPairManager.class)
 public class AccountProfileKeyPairManagerMixin {

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/annotation/CompositeDependencies.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/annotation/CompositeDependencies.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * CompositeDependencies annotation.
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CompositeDependencies {
     /**

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/annotation/Dependencies.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/annotation/Dependencies.java
@@ -1,13 +1,12 @@
 package top.hendrixshen.magiclib.api.dependency.annotation;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Dependencies annotation.
  */
-@Target({ /* No targets allowed */})
+@Repeatable(CompositeDependencies.class)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Dependencies {
     /**

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/EntryPointDependency.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/EntryPointDependency.java
@@ -1,26 +1,24 @@
 package top.hendrixshen.magiclib.impl.dependency;
 
 import com.google.common.collect.Lists;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
-import org.spongepowered.asm.util.Annotations;
 import top.hendrixshen.magiclib.MagicLib;
 import top.hendrixshen.magiclib.api.dependency.DependencyCheckException;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.i18n.I18n;
 import top.hendrixshen.magiclib.api.platform.DistType;
 import top.hendrixshen.magiclib.api.platform.adapter.ModContainerAdapter;
 import top.hendrixshen.magiclib.api.platform.adapter.ModMetaDataAdapter;
 import top.hendrixshen.magiclib.impl.gui.fabric.FabricGuiEntry;
-import top.hendrixshen.magiclib.util.ASMUtil;
+import top.hendrixshen.magiclib.util.DependencyUtil;
 import top.hendrixshen.magiclib.util.MiscUtil;
 import top.hendrixshen.magiclib.util.collect.InfoNode;
-import top.hendrixshen.magiclib.util.collect.ValueContainer;
 
 import java.util.List;
 import java.util.Objects;
@@ -28,14 +26,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 @ApiStatus.Internal
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EntryPointDependency {
     @Getter(lazy = true)
     private static final EntryPointDependency instance = new EntryPointDependency();
 
     private final AtomicBoolean isChecked = new AtomicBoolean();
-
-    private EntryPointDependency() {
-    }
 
     public void check() {
         if (this.isChecked.get()) {
@@ -89,14 +85,7 @@ public final class EntryPointDependency {
                 continue;
             }
 
-            ValueContainer<AnnotationNode> annotation = ASMUtil.getVisibleAnnotations(method,
-                    CompositeDependencies.class);
-
-            if (!annotation.isPresent()) {
-                continue;
-            }
-
-            return Annotations.<AnnotationNode>getValue(annotation.get(), "value", true)
+            return DependencyUtil.parseDependencies(method)
                     .stream()
                     .map(node -> DependenciesContainer.of(node, null))
                     .collect(Collectors.toList());

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/EntryPointDependency.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/EntryPointDependency.java
@@ -20,10 +20,10 @@ import top.hendrixshen.magiclib.util.DependencyUtil;
 import top.hendrixshen.magiclib.util.MiscUtil;
 import top.hendrixshen.magiclib.util.collect.InfoNode;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 @ApiStatus.Internal
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -57,7 +57,7 @@ public final class EntryPointDependency {
     }
 
     private @Nullable DependencyCheckException check(ModMetaDataAdapter modMetaDataAdapter, ClassNode entryPoint) {
-        List<DependenciesContainer<?>> dependencies = Lists.newArrayList();
+        List<DependenciesContainer<Object>> dependencies = Lists.newArrayList();
 
         if (MagicLib.getInstance().getCurrentPlatform().getCurrentDistType()
                 .matches(DistType.CLIENT)) {
@@ -85,12 +85,9 @@ public final class EntryPointDependency {
                 continue;
             }
 
-            return DependencyUtil.parseDependencies(method)
-                    .stream()
-                    .map(node -> DependenciesContainer.of(node, null))
-                    .collect(Collectors.toList());
+            return DependencyUtil.parseDependencies(method, null);
         }
 
-        return Lists.newArrayList();
+        return Collections.emptyList();
     }
 }

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
@@ -22,15 +22,15 @@ package top.hendrixshen.magiclib.impl.mixin.checker;
 
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
-import org.spongepowered.asm.util.Annotations;
 import top.hendrixshen.magiclib.api.dependency.DependencyCheckException;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.i18n.I18n;
 import top.hendrixshen.magiclib.api.mixin.checker.MixinDependencyCheckFailureCallback;
 import top.hendrixshen.magiclib.api.mixin.checker.MixinDependencyChecker;
 import top.hendrixshen.magiclib.impl.dependency.DependenciesContainer;
+import top.hendrixshen.magiclib.util.DependencyUtil;
 import top.hendrixshen.magiclib.util.MiscUtil;
 import top.hendrixshen.magiclib.util.collect.InfoNode;
+import top.hendrixshen.magiclib.util.collect.ValueContainer;
 import top.hendrixshen.magiclib.util.mixin.MixinUtil;
 
 import java.util.List;
@@ -51,8 +51,7 @@ public class SimpleMixinChecker implements MixinDependencyChecker {
             return false;
         }
 
-        AnnotationNode mixinConfigNode = Annotations.getVisible(mixinClassNode, CompositeDependencies.class);
-        List<AnnotationNode> nodes = Annotations.getValue(mixinConfigNode, "value", true);
+        List<AnnotationNode> nodes = DependencyUtil.parseDependencies(mixinClassNode);
 
         if (nodes.isEmpty()) {
             return true;

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
@@ -20,7 +20,6 @@
 
 package top.hendrixshen.magiclib.impl.mixin.checker;
 
-import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import top.hendrixshen.magiclib.api.dependency.DependencyCheckException;
 import top.hendrixshen.magiclib.api.i18n.I18n;
@@ -30,11 +29,9 @@ import top.hendrixshen.magiclib.impl.dependency.DependenciesContainer;
 import top.hendrixshen.magiclib.util.DependencyUtil;
 import top.hendrixshen.magiclib.util.MiscUtil;
 import top.hendrixshen.magiclib.util.collect.InfoNode;
-import top.hendrixshen.magiclib.util.collect.ValueContainer;
 import top.hendrixshen.magiclib.util.mixin.MixinUtil;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Reference to <a href="https://github.com/Fallen-Breath/conditional-mixin/blob/88cbb739c375925b134a464428a1f67ee3bd74e2/common/src/main/java/me/fallenbreath/conditionalmixin/impl/SimpleRestrictionChecker.java">conditional mixin<a/>
@@ -51,24 +48,19 @@ public class SimpleMixinChecker implements MixinDependencyChecker {
             return false;
         }
 
-        List<AnnotationNode> nodes = DependencyUtil.parseDependencies(mixinClassNode);
+        List<DependenciesContainer<ClassNode>> nodes = DependencyUtil.parseDependencies(mixinClassNode, targetClassNode);
 
         if (nodes.isEmpty()) {
             return true;
         }
 
-        List<DependenciesContainer<?>> dependencies = nodes
-                .stream()
-                .map(node -> DependenciesContainer.of(node, targetClassNode))
-                .collect(Collectors.toList());
-
-        if (dependencies.stream().anyMatch(DependenciesContainer::isSatisfied)) {
+        if (nodes.stream().anyMatch(DependenciesContainer::isSatisfied)) {
             return true;
         }
 
         InfoNode rootNode = new InfoNode(null, I18n.tr("magiclib.dependency.checker.mixin.title",
                 mixinClassName, targetClassName));
-        MiscUtil.generateDependencyCheckMessage(dependencies, rootNode);
+        MiscUtil.generateDependencyCheckMessage(nodes, rootNode);
         this.onCheckFailure(targetClassName, mixinClassName, new DependencyCheckException(rootNode.toString()));
 
         return false;

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/extension/AnnotationRestorerExtension.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/extension/AnnotationRestorerExtension.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.transformer.ext.ITargetClassContext;
 import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
+import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.mixin.extension.EmptyExtension;
 import top.hendrixshen.magiclib.impl.mixin.AnnotationRestorer;
 
@@ -23,6 +24,7 @@ public final class AnnotationRestorerExtension extends EmptyExtension {
 
     public AnnotationRestorerExtension() {
         AnnotationRestorerExtension.register(CompositeDependencies.class);
+        AnnotationRestorerExtension.register(Dependencies.class);
     }
 
     @Override

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/DependencyUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/DependencyUtil.java
@@ -9,9 +9,16 @@ import org.objectweb.asm.tree.MethodNode;
 import org.spongepowered.asm.util.Annotations;
 import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
+import top.hendrixshen.magiclib.impl.dependency.DependenciesContainer;
+import top.hendrixshen.magiclib.util.collect.ValueContainer;
 
+import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DependencyUtil {
     public static @NotNull List<AnnotationNode> parseDependencies(ClassNode classNode) {
@@ -60,5 +67,23 @@ public class DependencyUtil {
         }
 
         return Collections.emptyList();
+    }
+
+    public static <T> @NotNull List<DependenciesContainer<T>> parseDependencies(@NotNull Field field, T instance) {
+        List<DependenciesContainer<T>> composite = ReflectionUtil.getFieldAnnotation(field, CompositeDependencies.class)
+                .map(CompositeDependencies::value)
+                .map(Arrays::stream)
+                .orElse(Stream.empty())
+                .map(dependencies -> DependenciesContainer.of(dependencies, instance))
+                .collect(Collectors.toList());
+
+        if (!composite.isEmpty()) {
+            return composite;
+        }
+
+        return ReflectionUtil.getFieldAnnotation(field, Dependencies.class)
+                .stream()
+                .map(dependencies -> DependenciesContainer.of(dependencies, instance))
+                .collect(Collectors.toList());
     }
 }

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/DependencyUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/DependencyUtil.java
@@ -1,6 +1,5 @@
 package top.hendrixshen.magiclib.util;
 
-import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -16,57 +15,60 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DependencyUtil {
-    public static @NotNull List<AnnotationNode> parseDependencies(ClassNode classNode) {
-        AnnotationNode compositeNode = Annotations.getVisible(classNode, CompositeDependencies.class);
+    public static <T> List<DependenciesContainer<T>> parseDependencies(ClassNode classNode, T instance) {
+        List<DependenciesContainer<T>> composite = DependencyUtil.convertCompositeDependencies(ValueContainer
+                .ofNullable(Annotations.getVisible(classNode, CompositeDependencies.class)), instance);
 
-        if (compositeNode == null) {
-            AnnotationNode dependenciesNode = Annotations.getVisible(classNode, Dependencies.class);
-
-            if (dependenciesNode != null) {
-                return Lists.newArrayList(dependenciesNode);
-            }
-        } else {
-            return Annotations.getValue(compositeNode, "value", true);
+        if (!composite.isEmpty()) {
+            return composite;
         }
 
-        return Collections.emptyList();
+        return DependencyUtil.convertDependencies(ValueContainer.ofNullable(Annotations.getVisible(classNode,
+                Dependencies.class)), instance);
     }
 
-    public static @NotNull List<AnnotationNode> parseDependencies(MethodNode methodNode) {
-        AnnotationNode compositeNode = Annotations.getVisible(methodNode, CompositeDependencies.class);
+    public static @NotNull <T> List<DependenciesContainer<T>> parseDependencies(MethodNode methodNode, T instance) {
+        List<DependenciesContainer<T>> composite = DependencyUtil.convertCompositeDependencies(ValueContainer
+                .ofNullable(Annotations.getVisible(methodNode, CompositeDependencies.class)), instance);
 
-        if (compositeNode == null) {
-            AnnotationNode dependenciesNode = Annotations.getVisible(methodNode, Dependencies.class);
-
-            if (dependenciesNode != null) {
-                return Lists.newArrayList(dependenciesNode);
-            }
-        } else {
-            return Annotations.getValue(compositeNode, "value", true);
+        if (!composite.isEmpty()) {
+            return composite;
         }
 
-        return Collections.emptyList();
+        return DependencyUtil.convertDependencies(ValueContainer.ofNullable(Annotations.getVisible(methodNode,
+                Dependencies.class)), instance);
     }
 
-    public static @NotNull List<AnnotationNode> parseDependencies(FieldNode fieldNode) {
-        AnnotationNode compositeNode = Annotations.getVisible(fieldNode, CompositeDependencies.class);
+    public static @NotNull <T> List<DependenciesContainer<T>> parseDependencies(FieldNode fieldNode, T instance) {
+        List<DependenciesContainer<T>> composite = DependencyUtil.convertCompositeDependencies(ValueContainer
+                .ofNullable(Annotations.getVisible(fieldNode, CompositeDependencies.class)), instance);
 
-        if (compositeNode == null) {
-            AnnotationNode dependenciesNode = Annotations.getVisible(fieldNode, Dependencies.class);
-
-            if (dependenciesNode != null) {
-                return Lists.newArrayList(dependenciesNode);
-            }
-        } else {
-            return Annotations.getValue(compositeNode, "value", true);
+        if (!composite.isEmpty()) {
+            return composite;
         }
 
-        return Collections.emptyList();
+        return DependencyUtil.convertDependencies(ValueContainer.ofNullable(Annotations.getVisible(fieldNode,
+                Dependencies.class)), instance);
+    }
+
+    private static <T> List<DependenciesContainer<T>> convertCompositeDependencies(
+            @NotNull ValueContainer<AnnotationNode> composite, T instance) {
+        return composite.map(compositeNode -> Annotations.getValue(compositeNode, "value", true))
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(dependenciesNode -> DependenciesContainer.of((AnnotationNode) dependenciesNode, instance))
+                .collect(Collectors.toList());
+    }
+
+    private static <T> List<DependenciesContainer<T>> convertDependencies(
+            @NotNull ValueContainer<AnnotationNode> dependencies, T instance) {
+        return dependencies.stream()
+                .map(d -> DependenciesContainer.of(d, instance))
+                .collect(Collectors.toList());
     }
 
     public static <T> @NotNull List<DependenciesContainer<T>> parseDependencies(@NotNull Field field, T instance) {

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/DependencyUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/DependencyUtil.java
@@ -1,0 +1,64 @@
+package top.hendrixshen.magiclib.util;
+
+import com.google.common.collect.Lists;
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.util.Annotations;
+import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
+import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DependencyUtil {
+    public static @NotNull List<AnnotationNode> parseDependencies(ClassNode classNode) {
+        AnnotationNode compositeNode = Annotations.getVisible(classNode, CompositeDependencies.class);
+
+        if (compositeNode == null) {
+            AnnotationNode dependenciesNode = Annotations.getVisible(classNode, Dependencies.class);
+
+            if (dependenciesNode != null) {
+                return Lists.newArrayList(dependenciesNode);
+            }
+        } else {
+            return Annotations.getValue(compositeNode, "value", true);
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static @NotNull List<AnnotationNode> parseDependencies(MethodNode methodNode) {
+        AnnotationNode compositeNode = Annotations.getVisible(methodNode, CompositeDependencies.class);
+
+        if (compositeNode == null) {
+            AnnotationNode dependenciesNode = Annotations.getVisible(methodNode, Dependencies.class);
+
+            if (dependenciesNode != null) {
+                return Lists.newArrayList(dependenciesNode);
+            }
+        } else {
+            return Annotations.getValue(compositeNode, "value", true);
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static @NotNull List<AnnotationNode> parseDependencies(FieldNode fieldNode) {
+        AnnotationNode compositeNode = Annotations.getVisible(fieldNode, CompositeDependencies.class);
+
+        if (compositeNode == null) {
+            AnnotationNode dependenciesNode = Annotations.getVisible(fieldNode, Dependencies.class);
+
+            if (dependenciesNode != null) {
+                return Lists.newArrayList(dependenciesNode);
+            }
+        } else {
+            return Annotations.getValue(compositeNode, "value", true);
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/MiscUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/MiscUtil.java
@@ -26,7 +26,7 @@ public class MiscUtil {
         return (T) obj;
     }
 
-    public static void generateDependencyCheckMessage(@NotNull List<DependenciesContainer<?>> dependencies,
+    public static <T> void generateDependencyCheckMessage(@NotNull List<DependenciesContainer<T>> dependencies,
                                                       InfoNode rootNode) {
         boolean first = true;
         boolean composite = false;

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/mixin/MixinUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/mixin/MixinUtil.java
@@ -18,7 +18,7 @@ public class MixinUtil {
         try {
             return MixinService.getService().getBytecodeProvider().getClassNode(className);
         } catch (ClassNotFoundException | IOException e) {
-            MagicLib.getLogger().error("Failed to fetch class node {}: ", className, e);
+            MagicLib.getLogger().error("Failed to fetch class node {}: ", className);
         }
 
         return null;

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/MixinParsedRule.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/MixinParsedRule.java
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.api.mixin.annotation.MagicInit;
@@ -29,7 +28,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -37,23 +35,21 @@ import java.util.stream.Stream;
 
 //#if MC > 11802
 //$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-//#elseif MC <= 11605
-import top.hendrixshen.magiclib.carpet.impl.RuleHelper;
 //#else
-//#endif
-//#if MC <= 11802
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.util.MiscUtil;
+//#endif
+
+//#if MC > 11605
+//$$ import java.util.Collections;
+//#else
+import top.hendrixshen.magiclib.carpet.impl.RuleHelper;
 //#endif
 
 //#if MC > 11900
 //$$ @SuppressWarnings("removal")
 //#endif
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency("carpet")
-        )
-)
+@Dependencies(require = @Dependency("carpet"))
 @Mixin(ParsedRule.class)
 public abstract class MixinParsedRule<T> {
     // All field are dummy.

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/MixinSettingManager.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/MixinSettingManager.java
@@ -6,28 +6,23 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.carpet.impl.WrappedSettingManager;
 import top.hendrixshen.magiclib.util.MiscUtil;
 
-
 //#if MC > 11802
 //$$ import carpet.api.settings.SettingsManager;
 //#else
 import carpet.settings.SettingsManager;
+//#endif
+
 //#if MC < 11600
 //$$ import com.mojang.brigadier.CommandDispatcher;
 //$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 //#endif
-//#endif
 
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency("carpet")
-        )
-)
+@Dependencies(require = @Dependency("carpet"))
 @Mixin(value = SettingsManager.class, remap = false)
 public class MixinSettingManager {
     //#if MC < 11600

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/accessor/SettingsManagerAccessor.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/accessor/SettingsManagerAccessor.java
@@ -3,15 +3,8 @@ package top.hendrixshen.magiclib.mixin.carpet.accessor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
-
-//#if MC > 11502
-import java.nio.file.Path;
-//#else
-//$$ import org.apache.commons.lang3.tuple.Pair;
-//#endif
 
 //#if MC > 11900
 //$$ import carpet.api.settings.SettingsManager;
@@ -19,11 +12,16 @@ import java.nio.file.Path;
 import carpet.settings.ParsedRule;
 import carpet.settings.SettingsManager;
 import org.spongepowered.asm.mixin.gen.Accessor;
-
 import java.util.Map;
 //#endif
 
-@CompositeDependencies(@Dependencies(require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "carpet")))
+//#if MC > 11502
+import java.nio.file.Path;
+//#else
+//$$ import org.apache.commons.lang3.tuple.Pair;
+//#endif
+
+@Dependencies(require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "carpet"))
 @Mixin(value = SettingsManager.class, remap = false)
 public interface SettingsManagerAccessor {
     //#if MC < 11901

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/dev/MixinChunkMap.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/carpet/dev/MixinChunkMap.java
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
@@ -22,19 +21,14 @@ import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
  * Fix a stack overflow exception when you use Mojang Mappings in a development environment.
  * And since 1.18, carpet uses Mojang Mappings, this bug fixed itself.
  */
-@CompositeDependencies(
-        @Dependencies(
-                require = {
-                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
-                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
-                }
-        )
-)
+@Dependencies(require = {
+        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
+        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
+})
 @Mixin(value = ChunkMap.class, priority = 1001)
 public class MixinChunkMap {
     @Shadow
     private volatile Long2ObjectLinkedOpenHashMap<ChunkHolder> visibleChunkMap;
-
 
     @Inject(
             method = "getChunks",

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/malilib/MixinWidgetConfigOptionForHotkeyed.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/malilib/MixinWidgetConfigOptionForHotkeyed.java
@@ -24,7 +24,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.malilib.impl.config.MagicConfigHotkey;
@@ -32,7 +31,7 @@ import top.hendrixshen.magiclib.mixin.malilib.accessor.KeybindMultiAccessor;
 import top.hendrixshen.magiclib.util.StringUtil;
 
 @Environment(EnvType.CLIENT)
-@CompositeDependencies(@Dependencies(require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib")))
+@Dependencies(require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib"))
 @Mixin(value = WidgetConfigOption.class, remap = false)
 public abstract class MixinWidgetConfigOptionForHotkeyed extends WidgetConfigOptionBase<GuiConfigsBase.ConfigOptionWrapper> {
     public MixinWidgetConfigOptionForHotkeyed(int x, int y, int width, int height, WidgetListConfigOptionsBase<?, ?> parent, GuiConfigsBase.ConfigOptionWrapper entry, int listIndex) {

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/malilib/backport/MixinConfigBooleanHotkeyed.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/malilib/backport/MixinConfigBooleanHotkeyed.java
@@ -17,13 +17,12 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.malilib.MixinPredicates;
 
 @Environment(EnvType.CLIENT)
-@CompositeDependencies(@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.Malilib_0_11_4.class)))
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.Malilib_0_11_4.class))
 @Mixin(value = ConfigBooleanHotkeyed.class, remap = false)
 public abstract class MixinConfigBooleanHotkeyed extends ConfigBoolean implements IHotkeyTogglable {
     @Final

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/malilib/backport/MixinWidgetConfigOptionForBooleanHotkeyed.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/malilib/backport/MixinWidgetConfigOptionForBooleanHotkeyed.java
@@ -25,7 +25,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.malilib.MixinPredicates;
@@ -37,7 +36,7 @@ import java.util.List;
 import java.util.Objects;
 
 @Environment(EnvType.CLIENT)
-@CompositeDependencies(@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.Malilib_0_11_4.class)))
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.Malilib_0_11_4.class))
 @Mixin(value = WidgetConfigOption.class, remap = false)
 public abstract class MixinWidgetConfigOptionForBooleanHotkeyed extends WidgetConfigOptionBase<GuiConfigsBase.ConfigOptionWrapper> {
     @Mutable

--- a/magiclib-legacy-compat/versions/1.19.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/malilib/MixinWidgetConfigOptionForBooleanHotkeyed.java
+++ b/magiclib-legacy-compat/versions/1.19.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/malilib/MixinWidgetConfigOptionForBooleanHotkeyed.java
@@ -23,21 +23,12 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.malilib.impl.config.MagicConfigBooleanHotkeyed;
 
 @Environment(EnvType.CLIENT)
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(
-                        dependencyType = DependencyType.MOD_ID,
-                        value = "malilib",
-                        versionPredicates = ">=0.11.4"
-                )
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib", versionPredicates = ">=0.11.4"))
 @Mixin(value = WidgetConfigOption.class, remap = false)
 public abstract class MixinWidgetConfigOptionForBooleanHotkeyed extends WidgetConfigOptionBase<GuiConfigsBase.ConfigOptionWrapper> {
     @Shadow

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/api/malilib/annotation/Config.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/api/malilib/annotation/Config.java
@@ -22,9 +22,5 @@ public @interface Config {
 
     boolean devOnly() default false;
 
-    Statistic statistic() default @Statistic;
-
-    CompositeDependencies compositeDependencies() default @CompositeDependencies();
-
     String defaultCategory = "all";
 }

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/api/malilib/annotation/Statistic.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/api/malilib/annotation/Statistic.java
@@ -2,7 +2,7 @@ package top.hendrixshen.magiclib.api.malilib.annotation;
 
 import java.lang.annotation.*;
 
-@Target({ /* No targets allowed */})
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Statistic {
     boolean hotkey() default true;

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/Configs.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/Configs.java
@@ -21,7 +21,8 @@ public class Configs {
     private static final MagicConfigManager cm = SharedConstants.getConfigManager();
     private static final MagicConfigFactory cf = Configs.cm.getConfigFactory();
 
-    @Config(category = ConfigCategory.GENERIC, statistic = @Statistic(hotkey = false))
+    @Statistic(hotkey = false)
+    @Config(category = ConfigCategory.GENERIC)
     public static MagicConfigHotkey openConfigGui = Configs.cf.newConfigHotkey("openConfigGui", "M,A,G");
 
     @Config(category = ConfigCategory.DEBUG)
@@ -30,10 +31,12 @@ public class Configs {
     @Config(category = ConfigCategory.DEBUG, debugOnly = true)
     public static MagicConfigBoolean hideUnavailableConfigs = Configs.cf.newConfigBoolean("hideUnavailableConfigs", true);
 
-    @Config(category = ConfigCategory.DEBUG, debugOnly = true, statistic = @Statistic(hotkey = false))
+    @Statistic(hotkey = false)
+    @Config(category = ConfigCategory.DEBUG, debugOnly = true)
     public static MagicConfigHotkey resetAllConfigStatistic = Configs.cf.newConfigHotkey("resetAllConfigStatistic");
 
-    @Config(category = ConfigCategory.DEBUG, debugOnly = true, statistic = @Statistic(hotkey = false))
+    @Statistic(hotkey = false)
+    @Config(category = ConfigCategory.DEBUG, debugOnly = true)
     public static MagicConfigHotkey resetMagicLibConfigStatistic = Configs.cf.newConfigHotkey("resetMagicLibConfigStatistic");
 
     @Config(category = ConfigCategory.TEST, debugOnly = true)
@@ -69,41 +72,25 @@ public class Configs {
     @Config(category = ConfigCategory.TEST, debugOnly = true)
     public static final MagicConfigStringList testConfigStringList = Configs.cf.newConfigStringList("testConfigStringList", ImmutableList.of("test1", "test2"));
 
-    @Config(category = ConfigCategory.TEST, debugOnly = true, compositeDependencies = @CompositeDependencies(
-            {
-                    @Dependencies(
-                            conflict = {
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<2.0"),
-                            },
-                            require = {
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "dummy-lib", versionPredicates = "*")
-                            }
-                    )
-            }
-    ))
+    @Dependencies(
+            conflict = @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<2.0"),
+            require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "dummy-lib", versionPredicates = "*")
+    )
+    @Config(category = ConfigCategory.TEST, debugOnly = true)
     public static MagicConfigBoolean testDependencies = Configs.cf.newConfigBoolean("testDependencies", false);
 
-    @Config(category = ConfigCategory.TEST, debugOnly = true, compositeDependencies = @CompositeDependencies(
-            {
-                    @Dependencies(
-                            conflict = {
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<2.0"),
-                            },
-                            require = {
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "dummy-lib", versionPredicates = "*")
-                            }
-                    ),
-                    @Dependencies(
-                            conflict = {
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "magiclib_core", versionPredicates = "*"),
-                            },
-                            require = {
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "*"),
-                                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "dummy", versionPredicates = ">0.15.5")
-                            }
-                    )
+    @Dependencies(
+            conflict = @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<2.0"),
+            require = @Dependency(dependencyType = DependencyType.MOD_ID, value = "dummy-lib", versionPredicates = "*")
+    )
+    @Dependencies(
+            conflict = @Dependency(dependencyType = DependencyType.MOD_ID, value = "magiclib_core", versionPredicates = "*"),
+            require = {
+                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "*"),
+                    @Dependency(dependencyType = DependencyType.MOD_ID, value = "dummy", versionPredicates = ">0.15.5")
             }
-    ))
+    )
+    @Config(category = ConfigCategory.TEST, debugOnly = true)
     public static MagicConfigBoolean testDependenciesComposite = Configs.cf.newConfigBoolean("testDependenciesComposite", false);
 
     public static void init() {

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/MagicConfigManagerImpl.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/MagicConfigManagerImpl.java
@@ -60,7 +60,7 @@ public class MagicConfigManagerImpl implements MagicConfigManager, IKeybindProvi
                     continue;
                 }
 
-                ConfigContainer configContainer = new ConfigContainer(annotation, (MagicIConfigBase) config);
+                ConfigContainer configContainer = new ConfigContainer(annotation, field, (MagicIConfigBase) config);
                 this.CONTAINERS.add(configContainer);
                 this.CATEGORIES.add(configContainer.getCategory());
                 this.CATEGORY_TO_CONTAINERS.computeIfAbsent(configContainer.getCategory(),

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/config/MagicConfigBooleanHotkeyedMixin.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/config/MagicConfigBooleanHotkeyedMixin.java
@@ -10,17 +10,12 @@ import fi.dy.masa.malilib.util.JsonUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import top.hendrixshen.magiclib.MagicLib;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.malilib.MixinPredicates;
 import top.hendrixshen.magiclib.impl.malilib.config.option.MagicConfigBooleanHotkeyed;
 
-@CompositeDependencies(
-        @Dependencies(
-                require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.Malilib_0_11_4.class)
-        )
-)
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.Malilib_0_11_4.class))
 @Mixin(value = MagicConfigBooleanHotkeyed.class, remap = false)
 public abstract class MagicConfigBooleanHotkeyedMixin extends ConfigBoolean implements IHotkeyTogglable {
     public MagicConfigBooleanHotkeyedMixin(String name, boolean defaultValue, String comment) {

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
@@ -10,28 +10,19 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
-import top.hendrixshen.magiclib.api.dependency.annotation.CompositeDependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
 
-@CompositeDependencies({
-        @Dependencies(
-                require = {
-                        @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib"),
-                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
-                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class),
-
-                }
-        ),
-        @Dependencies(
-                require = {
-                        @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib"),
-                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
-                        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class),
-
-                }
-        )
+@Dependencies(require = {
+        @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib"),
+        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
+        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
+})
+@Dependencies(require = {
+        @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib"),
+        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
+        @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
 })
 @Mixin(value = GuiTextFieldGeneric.class, remap = false)
 public class GuiTextFieldGenericMixin extends EditBox {


### PR DESCRIPTION
## Features

This pr mainly makes some nested annotations directly usable.

Note: This a breaking change that may break compatibility

- [x] MixinPlugin dependency check
- [x] Entrypoints dependency check
- [x] Malilib Config dependency check & statistic setting