### PR TITLE
Minecraft 1.21 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,9 +23,9 @@ dependencies.lombok_version=1.18.34
 dependencies.jetbrains_annotations_version=24.1.0
 
 # Gradle Plugins
-architectury_loom_version=1.6-SNAPSHOT
+architectury_loom_version=1.7-SNAPSHOT
 grgit_version=5.2.2
-preprocessor_version=ce1aeb2b
+preprocessor_version=88169fcb
 replace_token_version=1.1.2
 shadow_version=8.1.1
 yamlang_version=1.3.1

--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -23,6 +23,7 @@ preprocess {
     Node mc_12002_fabric = createNode("better-dev-1.20.2-fabric", 1_20_02, "mojang")
     Node mc_12004_fabric = createNode("better-dev-1.20.4-fabric", 1_20_04, "mojang")
     Node mc_12006_fabric = createNode("better-dev-1.20.6-fabric", 1_20_06, "mojang")
+    Node mc_12100_fabric = createNode("better-dev-1.21.0-fabric", 1_21_00, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, file("versions/mapping-fabric-1.15.2-1.16.5.txt"))
@@ -35,6 +36,7 @@ preprocess {
     mc_12001_fabric.link(mc_12002_fabric, null)
     mc_12002_fabric.link(mc_12004_fabric, null)
     mc_12004_fabric.link(mc_12006_fabric, null)
+    mc_12006_fabric.link(mc_12100_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("better-dev-1.17.1-forge", 1_17_01, "mojang")

--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -42,17 +42,19 @@ preprocess {
     Node mc_11701_forge = createNode("better-dev-1.17.1-forge", 1_17_01, "mojang")
     Node mc_11802_forge = createNode("better-dev-1.18.2-forge", 1_18_02, "mojang")
     Node mc_11904_forge = createNode("better-dev-1.19.4-forge", 1_19_04, "mojang")
-    Node mc_11206_forge = createNode("better-dev-1.20.6-forge", 1_20_06, "mojang")
+    Node mc_12006_forge = createNode("better-dev-1.20.6-forge", 1_20_06, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, file("versions/mapping-1.17.1-fabric-forge.txt"))
     mc_11802_fabric.link(mc_11802_forge, file("versions/mapping-1.18.2-fabric-forge.txt"))
     mc_11904_fabric.link(mc_11904_forge, file("versions/mapping-1.19.4-fabric-forge.txt"))
-    mc_12006_fabric.link(mc_11206_forge, file("versions/mapping-1.20.6-fabric-forge.txt"))
+    mc_12006_fabric.link(mc_12006_forge, file("versions/mapping-1.20.6-fabric-forge.txt"))
 
     // NeoForge
     Node mc_12002_neoforge = createNode("better-dev-1.20.2-neoforge", 1_20_02, "mojang")
     Node mc_12006_neoforge = createNode("better-dev-1.20.6-neoforge", 1_20_06, "mojang")
+    Node mc_12100_neoforge = createNode("better-dev-1.21.0-neoforge", 1_21_00, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
     mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
+    mc_12100_fabric.link(mc_12100_neoforge, file("versions/mapping-1.21.0-fabric-neoforge.txt"))
 }

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/impl/dev/threadtweak/ThreadTweaker.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/impl/dev/threadtweak/ThreadTweaker.java
@@ -35,6 +35,10 @@ import top.hendrixshen.magiclib.mixin.dev.accessor.UtilAccessor;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+//#if MC > 12006
+//$$ import net.minecraft.ReportType;
+//#endif
+
 /**
  * Reference to <a ref="https://github.com/UltimateBoomer/mc-smoothboot/blob/ce5c0482e51698a424ea3d09e994d4b71a7c71b6/src/main/java/io/github/ultimateboomer/smoothboot/mixin/UtilMixin.java">SmoothBoot</a>
  */
@@ -69,7 +73,11 @@ public class ThreadTweaker {
             }
 
             if (throwable instanceof ReportedException) {
-                Bootstrap.realStdoutPrintln(((ReportedException) throwable).getReport().getFriendlyReport());
+                Bootstrap.realStdoutPrintln(((ReportedException) throwable).getReport().getFriendlyReport(
+                        //#if MC > 12006
+                        //$$ ReportType.CRASH
+                        //#endif
+                ));
                 System.exit(-1);
             }
 

--- a/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/MainMixin.java
+++ b/magiclib-better-dev/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/MainMixin.java
@@ -1,0 +1,8 @@
+package top.hendrixshen.magiclib.mixin.dev.dfu.lazy;
+
+import org.spongepowered.asm.mixin.Mixin;
+import top.hendrixshen.magiclib.api.preprocess.DummyClass;
+
+@Mixin(DummyClass.class)
+public class MainMixin {
+}

--- a/magiclib-better-dev/src/main/resources/magiclib-better-dev.mixins.json
+++ b/magiclib-better-dev/src/main/resources/magiclib-better-dev.mixins.json
@@ -13,6 +13,7 @@
     "dfu.destroy.DataFixerUpperMixin",
     "dfu.destroy.SchemaMixin",
     "dfu.lazy.DataFixersMixin",
+    "dfu.lazy.MainMixin",
     "dfu.lazy.SharedConstantsMixin",
     "threadtweak.DataFixersMixin",
     "threadtweak.MinecraftServerMixin",

--- a/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
@@ -197,22 +197,25 @@ loom {
     // Setup client default settings.
     runClient {
         defaultCharacterEncoding("UTF-8")
-        file("${projectDir}/run/client/config").mkdirs()
-        file("${projectDir}/run/client/options.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("autoJump:false")
-                        writer.writeLine("enableVsync:false")
-                        writer.writeLine("forceUnicodeFont:true")
-                        writer.writeLine("fov:1.0")
-                        writer.writeLine("gamma:16.0")
-                        writer.writeLine("guiScale:3")
-                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                        writer.writeLine("maxFps:260")
-                        writer.writeLine("renderDistance:10")
-                        writer.writeLine("soundCategory_master:0.0")
+
+        doFirst {
+            file("${projectDir}/run/client/config").mkdirs()
+            file("${projectDir}/run/client/options.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("autoJump:false")
+                            writer.writeLine("enableVsync:false")
+                            writer.writeLine("forceUnicodeFont:true")
+                            writer.writeLine("fov:1.0")
+                            writer.writeLine("gamma:16.0")
+                            writer.writeLine("guiScale:3")
+                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                            writer.writeLine("maxFps:260")
+                            writer.writeLine("renderDistance:10")
+                            writer.writeLine("soundCategory_master:0.0")
+                        }
                     }
                 }
             }
@@ -223,25 +226,20 @@ loom {
     runServer {
         defaultCharacterEncoding("UTF-8")
 
-        // Agree eula before server init.
-        file("${projectDir}/run/server/eula.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                        writer.writeLine("#${new Date()}")
-                        writer.writeLine("eula=true")
+        doFirst {
+            // Agree eula before server init.
+            file("${projectDir}/run/server/eula.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                            writer.writeLine("#${new Date()}")
+                            writer.writeLine("eula=true")
+                        }
                     }
                 }
             }
-        }
-
-        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-            new File("${projectDir}/run/server").mkdirs()
-            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-            bufferedWriter.writeLine("eula=true")
-            bufferedWriter.close()
         }
     }
 }
@@ -437,7 +435,26 @@ tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     }
 }
 
+tasks.register("cleanRuns", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).parentFile.deleteDir()
+    }
+}
+
+tasks.register("cleanRunClient", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).deleteDir()
+    }
+}
+
+tasks.register("cleanRunServer", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.server.runDir).deleteDir()
+    }
+}
+
 [
+        "cleanRuns", "cleanRunClient", "cleanRunServer",
         "runClient", "runServer",
         "runMixinAuditClient", "runMixinAuditServer",
         "preprocessCode", "preprocessResources",

--- a/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
@@ -60,10 +60,6 @@ repositories {
     maven {
         name("Jitpack Maven")
         url("https://jitpack.io")
-
-        content {
-            includeGroup("com.github.Nyan-Work")
-        }
     }
 
     mavenCentral()
@@ -172,71 +168,72 @@ loom {
         runDir("run/server")
     }
 
-    runs {
-        mixinAuditClient {
-            inherit(client)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/client")
-        }
+    if (fabricLike) {
+        runs {
+            mixinAuditClient {
+                inherit(client)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/client")
+            }
 
-        mixinAuditServer {
-            inherit(server)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/server")
+            mixinAuditServer {
+                inherit(server)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/server")
+            }
         }
     }
 
-    if (fabricLike) {
-        // Setup client default settings.
-        runClient {
-            defaultCharacterEncoding("UTF-8")
-            file("${projectDir}/run/client/config").mkdirs()
-            file("${projectDir}/run/client/options.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("autoJump:false")
-                            writer.writeLine("enableVsync:false")
-                            writer.writeLine("forceUnicodeFont:true")
-                            writer.writeLine("fov:1.0")
-                            writer.writeLine("gamma:16.0")
-                            writer.writeLine("guiScale:3")
-                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                            writer.writeLine("maxFps:260")
-                            writer.writeLine("renderDistance:10")
-                            writer.writeLine("soundCategory_master:0.0")
-                        }
+    // Setup client default settings.
+    runClient {
+        defaultCharacterEncoding("UTF-8")
+        file("${projectDir}/run/client/config").mkdirs()
+        file("${projectDir}/run/client/options.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("autoJump:false")
+                        writer.writeLine("enableVsync:false")
+                        writer.writeLine("forceUnicodeFont:true")
+                        writer.writeLine("fov:1.0")
+                        writer.writeLine("gamma:16.0")
+                        writer.writeLine("guiScale:3")
+                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                        writer.writeLine("maxFps:260")
+                        writer.writeLine("renderDistance:10")
+                        writer.writeLine("soundCategory_master:0.0")
+                    }
+                }
+            }
+        }
+    }
+
+    // Setup server default settings.
+    runServer {
+        defaultCharacterEncoding("UTF-8")
+
+        // Agree eula before server init.
+        file("${projectDir}/run/server/eula.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                        writer.writeLine("#${new Date()}")
+                        writer.writeLine("eula=true")
                     }
                 }
             }
         }
 
-        // Setup server default settings.
-        runServer {
-            defaultCharacterEncoding("UTF-8")
-
-            // Agree eula before server init.
-            file("${projectDir}/run/server/eula.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                            writer.writeLine("#${new Date()}")
-                            writer.writeLine("eula=true")
-                        }
-                    }
-                }
-            }
-            if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-                new File("${projectDir}/run/server").mkdirs()
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-                bufferedWriter.writeLine("eula=true")
-                bufferedWriter.close()
-            }
+        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
+            new File("${projectDir}/run/server").mkdirs()
+            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
+            bufferedWriter.writeLine("eula=true")
+            bufferedWriter.close()
         }
     }
 }

--- a/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
@@ -71,15 +71,15 @@ repositories {
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def apiDependencies = [
-        ["maven.modrinth:modmenu"            , "modmenu", modPlatform == "fabric", false],
-        ["net.fabricmc.fabric-api:fabric-api", "fabric" , modPlatform == "fabric", true],
+        ["maven.modrinth:modmenu"            , "modmenu", fabricLike, false],
+        ["net.fabricmc.fabric-api:fabric-api", "fabric" , fabricLike, true],
 ]
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def runtimeDependencies = [
-        ["maven.modrinth:in-game-account-switcher", "inGameAccountSwitcher", fabricLike || mcVersion < 11202, false],
-        ["maven.modrinth:imblocker"               , "imblockerfabric"      , fabricLike && mcVersion < 12002, false],
-        ["maven.modrinth:imblocker-original"      , "imblocker"            , forgeLike  && false            , false],
+        ["maven.modrinth:in-game-account-switcher", "inGameAccountSwitcher", fabricLike, false],
+        ["maven.modrinth:imblocker"               , "imblockerfabric"      , fabricLike, false],
+        ["maven.modrinth:imblocker-original"      , "imblocker"            , forgeLike , false],
 ]
 
 dependencies {
@@ -108,12 +108,12 @@ dependencies {
     // API
     apiDependencies.forEach { item ->
         String dependencyNotation = item[0]
-        String propertyPrefix = item[1]
-        boolean shouldResolve = item[2]
+        String dependencyVersion = project.findProperty("dependencies.api.${item[1]}_version")
+        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
-            modApi("${dependencyNotation}:${project.property("dependencies.api.${propertyPrefix}_version")}") {
+            modApi("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
         }
@@ -122,12 +122,12 @@ dependencies {
     // Runtime Library - Make development environment comfortable.
     runtimeDependencies.forEach { item ->
         String dependencyNotation = item[0]
-        String propertyPrefix = item[1]
-        boolean shouldResolve = item[2]
+        String dependencyVersion = project.findProperty("dependencies.runtime.${item[1]}_version")
+        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
-            modRuntimeOnly("${dependencyNotation}:${project.property("dependencies.runtime.${propertyPrefix}_version")}") {
+            modRuntimeOnly("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
         }

--- a/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.14.4-fabric/build.gradle
@@ -74,7 +74,7 @@ def apiDependencies = [
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def runtimeDependencies = [
         ["maven.modrinth:in-game-account-switcher", "inGameAccountSwitcher", fabricLike, false],
-        ["maven.modrinth:imblocker"               , "imblockerfabric"      , fabricLike, false],
+        ["maven.modrinth:imblocker"               , "imblocker"            , fabricLike, false],
         ["maven.modrinth:imblocker-original"      , "imblocker"            , forgeLike , false],
 ]
 
@@ -105,10 +105,14 @@ dependencies {
     apiDependencies.forEach { item ->
         String dependencyNotation = item[0]
         String dependencyVersion = project.findProperty("dependencies.api.${item[1]}_version")
-        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
+        boolean shouldResolve = item[2] && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
+            if (!dependencyVersion) {
+                throw new RuntimeException("Could not get unknown property 'dependencies.api.${item[1]}_version' for dependency ${item[0]} in project ${project.name}")
+            }
+
             modApi("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
@@ -119,10 +123,14 @@ dependencies {
     runtimeDependencies.forEach { item ->
         String dependencyNotation = item[0]
         String dependencyVersion = project.findProperty("dependencies.runtime.${item[1]}_version")
-        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
+        boolean shouldResolve = item[2] && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
+            if (!dependencyVersion) {
+                throw new RuntimeException("Could not get unknown property 'dependencies.api.${item[1]}_version' for dependency ${item[0]} in project ${project.name}")
+            }
+
             modRuntimeOnly("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }

--- a/magiclib-better-dev/versions/1.14.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.14.4-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=1.7.17
 
 # IMBlockerFabric 1.0.20
 # imblockerfabric-1.0.20.jar
-dependencies.runtime.imblockerfabric_version=1.0.20
+dependencies.runtime.imblocker_version=1.0.20
 # In-Game Account Switcher 8.0.1
 # InGameAccountSwitcher-Fabric-1.14-8.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=8.0.1-fabric1.14

--- a/magiclib-better-dev/versions/1.15.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.15.2-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=1.10.7
 
 # IMBlockerFabric 1.0.20
 # imblockerfabric-1.0.20.jar
-dependencies.runtime.imblockerfabric_version=1.0.20
+dependencies.runtime.imblocker_version=1.0.20
 # In-Game Account Switcher 8.0.1
 # InGameAccountSwitcher-Fabric-1.15-8.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=8.0.1-fabric1.15

--- a/magiclib-better-dev/versions/1.16.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.16.5-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=1.16.23
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 8.0.1
 # InGameAccountSwitcher-Fabric-1.16-8.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=8.0.1-fabric1.16

--- a/magiclib-better-dev/versions/1.17.1-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.17.1-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=2.0.17
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 8.0.1
 # InGameAccountSwitcher-Fabric-1.17-8.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=8.0.1-fabric1.17

--- a/magiclib-better-dev/versions/1.17.1-forge/gradle.properties
+++ b/magiclib-better-dev/versions/1.17.1-forge/gradle.properties
@@ -4,7 +4,6 @@ dependencies.minecraft_dependency=1.17.x
 dependencies.minecraft_version=1.17.1
 
 # IMBlocker
-# TODO
 dependencies.runtime.imblocker_version=0
 # In-Game Account Switcher 8.0.1
 # InGameAccountSwitcher-Forge-1.17-8.0.1.jar

--- a/magiclib-better-dev/versions/1.18.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.18.2-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=3.2.5
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.0
 # IAS-Fabric-1.18.2-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=9.0.0

--- a/magiclib-better-dev/versions/1.18.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.18.2-fabric/gradle.properties
@@ -2,8 +2,8 @@
 dependencies.minecraft_dependency=1.18.x
 dependencies.minecraft_version=1.18.2
 
-# Fabric API 0.76.0+1.18.2
-dependencies.api.fabric_version=0.76.0+1.18.2
+# Fabric API 0.77.0+1.18.2
+dependencies.api.fabric_version=0.77.0+1.18.2
 # Mod Menu - 3.2.5
 # modmenu-3.2.5.jar
 dependencies.api.modmenu_version=3.2.5

--- a/magiclib-better-dev/versions/1.18.2-forge/gradle.properties
+++ b/magiclib-better-dev/versions/1.18.2-forge/gradle.properties
@@ -4,8 +4,8 @@ dependencies.minecraft_dependency=1.18.x
 dependencies.minecraft_version=1.18.2
 
 # IMBlocker
-# TODO
-dependencies.runtime.imblocker_version=0
+# IMBlocker_4.0.5+1.18.2.jar
+dependencies.runtime.imblocker_version=i9bOalx4
 # In-Game Account Switcher 9.0.0
 # IAS-Forge-1.18.2-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=WkxcHJkS

--- a/magiclib-better-dev/versions/1.19.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.2-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=4.2.0-beta.2
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.0
 # IAS-Fabric-1.19.2-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=4WyhQU59

--- a/magiclib-better-dev/versions/1.19.3-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.3-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=5.1.0
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 8.0.1.1
 # InGameAccountSwitcher-Fabric-1.19-8.0.1.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=8.0.1.1-fabric1.19

--- a/magiclib-better-dev/versions/1.19.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.4-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=6.3.1
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.0
 # IAS-Fabric-1.19.4-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=zo8AWOHP

--- a/magiclib-better-dev/versions/1.19.4-forge/gradle.properties
+++ b/magiclib-better-dev/versions/1.19.4-forge/gradle.properties
@@ -3,9 +3,9 @@ dependencies.forge_version=45.2.15
 dependencies.minecraft_dependency=1.19.4
 dependencies.minecraft_version=1.19.4
 
-# IMBlocker
-# TODO
-dependencies.runtime.imblocker_version=0
+# IMBlocker 4.0.9b
+# IMBlocker_4.0.9b+1.19.4.jar
+dependencies.runtime.imblocker_version=4.0.9b+1.19.4
 # In-Game Account Switcher 9.0.0
 # IAS-Forge-1.19.4-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=M7h7VI3V

--- a/magiclib-better-dev/versions/1.20.1-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.1-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=7.2.2
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.0
 # IAS-Fabric-1.20.1-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=3lDWPamo

--- a/magiclib-better-dev/versions/1.20.2-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.2-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=8.0.1
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.0
 # IAS-Fabric-1.20.2-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=KMG9GrSq

--- a/magiclib-better-dev/versions/1.20.2-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.2-neoforge/gradle.properties
@@ -4,7 +4,6 @@ dependencies.minecraft_dependency=1.20.2
 dependencies.minecraft_version=1.20.2
 
 # IMBlocker
-# TODO
 dependencies.runtime.imblocker_version=0
 # In-Game Account Switcher 9.0.0
 # IAS-NeoForge-1.20.2-9.0.0.jar

--- a/magiclib-better-dev/versions/1.20.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.4-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=9.2.0
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.1
 # IAS-Fabric-1.20.4-9.0.0.jar
 dependencies.runtime.inGameAccountSwitcher_version=dHZaRsM5

--- a/magiclib-better-dev/versions/1.20.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.4-fabric/gradle.properties
@@ -12,8 +12,8 @@ dependencies.api.modmenu_version=9.2.0
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblockerfabric_version=1.0.24
 # In-Game Account Switcher 9.0.1
-# IAS-Fabric-1.20.6-9.0.1.jar
-dependencies.runtime.inGameAccountSwitcher_version=9.0.1
+# IAS-Fabric-1.20.4-9.0.0.jar
+dependencies.runtime.inGameAccountSwitcher_version=dHZaRsM5
 
 # Publish properties
 publish.game_version=1.20.3\n1.20.4

--- a/magiclib-better-dev/versions/1.20.6-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.6-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=10.0.0
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.1
 # IAS-Fabric-1.20.6-9.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=9.0.1

--- a/magiclib-better-dev/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.6-neoforge/gradle.properties
@@ -3,9 +3,9 @@ dependencies.neoforge_version=20.6.100-beta
 dependencies.minecraft_dependency=1.20.6
 dependencies.minecraft_version=1.20.6
 
-# IMBlocker
-# TODO
-dependencies.runtime.imblocker_version=0
+# IMBlocker 4.0.9b
+# IMBlocker_4.0.9b+1.20.6.jar
+dependencies.runtime.imblocker_version=4.0.9b+1.20.6
 # In-Game Account Switcher 9.0.1
 # IAS-NeoForge-1.20.6-9.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=rdiakbKb

--- a/magiclib-better-dev/versions/1.21.0-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.0-fabric/gradle.properties
@@ -2,8 +2,8 @@
 dependencies.minecraft_dependency=>=1.21- <1.21.1-
 dependencies.minecraft_version=1.21
 
-# Fabric API 0.100.4+1.20.6
-dependencies.api.fabric_version=0.100.4+1.21
+# Fabric API 0.100.6+1.21
+dependencies.api.fabric_version=0.100.6+1.21
 # Mod Menu 11.0.1
 # modmenu-11.0.1.jar
 dependencies.api.modmenu_version=11.0.1

--- a/magiclib-better-dev/versions/1.21.0-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.0-fabric/gradle.properties
@@ -1,0 +1,19 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21- <1.21.1-
+dependencies.minecraft_version=1.21
+
+# Fabric API 0.100.4+1.20.6
+dependencies.api.fabric_version=0.100.4+1.21
+# Mod Menu 11.0.1
+# modmenu-11.0.1.jar
+dependencies.api.modmenu_version=11.0.1
+
+# IMBlockerFabric 1.0.24
+# imblockerfabric-1.0.24.jar
+dependencies.runtime.imblockerfabric_version=1.0.24
+# In-Game Account Switcher 9.0.1
+# IAS-Fabric-1.21-9.0.1.jar
+dependencies.runtime.inGameAccountSwitcher_version=RQG6VufY
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-better-dev/versions/1.21.0-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.0-fabric/gradle.properties
@@ -10,7 +10,7 @@ dependencies.api.modmenu_version=11.0.1
 
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
-dependencies.runtime.imblockerfabric_version=1.0.24
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher 9.0.1
 # IAS-Fabric-1.21-9.0.1.jar
 dependencies.runtime.inGameAccountSwitcher_version=RQG6VufY

--- a/magiclib-better-dev/versions/1.21.0-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/MainMixin.java
+++ b/magiclib-better-dev/versions/1.21.0-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/MainMixin.java
@@ -1,0 +1,31 @@
+package top.hendrixshen.magiclib.mixin.dev.dfu.lazy;
+
+import com.mojang.datafixers.DSL;
+import net.minecraft.client.main.Main;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import top.hendrixshen.magiclib.api.dependency.DependencyType;
+import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
+import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
+import top.hendrixshen.magiclib.impl.dev.MixinPredicates;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+@Dependencies(require = @Dependency(dependencyType = DependencyType.PREDICATE, predicate = MixinPredicates.LazyDFUPredicate.class))
+@Mixin(Main.class)
+public class MainMixin {
+    @Redirect(
+            method = "main",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/util/datafix/DataFixers;optimize(Ljava/util/Set;)Ljava/util/concurrent/CompletableFuture;"
+            ),
+            require = 0
+    )
+    private static @NotNull CompletableFuture<?> doNotBuild(Set<DSL.TypeReference> set) {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/magiclib-better-dev/versions/1.21.0-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/SharedConstantsMixin.java
+++ b/magiclib-better-dev/versions/1.21.0-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/dfu/lazy/SharedConstantsMixin.java
@@ -1,0 +1,8 @@
+package top.hendrixshen.magiclib.mixin.dev.dfu.lazy;
+
+import org.spongepowered.asm.mixin.Mixin;
+import top.hendrixshen.magiclib.api.preprocess.DummyClass;
+
+@Mixin(DummyClass.class)
+public class SharedConstantsMixin {
+}

--- a/magiclib-better-dev/versions/1.21.0-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/DataFixersMixin.java
+++ b/magiclib-better-dev/versions/1.21.0-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/threadtweak/DataFixersMixin.java
@@ -1,0 +1,8 @@
+package top.hendrixshen.magiclib.mixin.dev.threadtweak;
+
+import org.spongepowered.asm.mixin.Mixin;
+import top.hendrixshen.magiclib.api.preprocess.DummyClass;
+
+@Mixin(DummyClass.class)
+public class DataFixersMixin {
+}

--- a/magiclib-better-dev/versions/1.21.0-fabric/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.21.0-fabric/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.0-neoforge/gradle.properties
@@ -1,0 +1,17 @@
+# Dependency Versions
+dependencies.neoforge_version=21.0.78-beta
+dependencies.minecraft_dependency=1.21
+dependencies.minecraft_version=1.21
+
+# IMBlocker 4.0.9b
+# IMBlocker_4.0.9b+1.21.jar
+dependencies.runtime.imblocker_version=4.0.9b+1.21
+# In-Game Account Switcher 9.0.1
+# IAS-NeoForge-1.21-9.0.1.jar
+dependencies.runtime.inGameAccountSwitcher_version=erRoWz06
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-better-dev/versions/1.21.0-neoforge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.21.0-neoforge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/mapping-1.21.0-fabric-neoforge.txt
+++ b/magiclib-better-dev/versions/mapping-1.21.0-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/DependencyContainer.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/DependencyContainer.java
@@ -146,7 +146,8 @@ public class DependencyContainer<T> {
 
                 return ValueContainer.of(new DependencyCheckResult(this.optional,
                         I18n.tr("magiclib.dependency.result.mod_id." + (this.optional ?
-                                "optional.success" : "require.fail") + ".not_found", this.value, this.versionPredicates)
+                                "optional.success" : "require.fail") + ".not_found", this.value,
+                                this.versionPredicates.isEmpty() ? "[*]" : this.versionPredicates)
                 ));
             case PREDICATE:
                 boolean testResult = this.predicate.test(this.obj);

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/FileLanguageProvider.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/FileLanguageProvider.java
@@ -2,6 +2,8 @@ package top.hendrixshen.magiclib.impl.i18n.provider;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.MalformedJsonException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -73,6 +75,11 @@ public class FileLanguageProvider implements LanguageProvider {
                 JsonUtil.loadStringMapFromJson(inputStream, result::put);
                 MagicLib.getLogger().debug("Loaded language file {}.", file);
             } catch (Exception e) {
+                if (e instanceof JsonSyntaxException && e.getCause() instanceof MalformedJsonException) {
+                    MagicLib.getLogger().error("Failed to load language file {}.", file);
+                    return;
+                }
+
                 MagicLib.getLogger().error("Failed to load language file {}.", file, e);
             }
         });

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/JarLanguageProvider.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/JarLanguageProvider.java
@@ -82,7 +82,7 @@ public class JarLanguageProvider implements LanguageProvider {
             } catch (Exception e) {
                 if (e instanceof JsonSyntaxException && e.getCause() instanceof MalformedJsonException) {
                     MagicLib.getLogger().error("Failed to load language file {} from {}.",
-                            entry.getName(), jar.getName(), e.getCause());
+                            entry.getName(), jar.getName());
                     continue;
                 }
 

--- a/magiclib-legacy-compat/build.gradle
+++ b/magiclib-legacy-compat/build.gradle
@@ -23,6 +23,7 @@ preprocess {
     Node mc_12002_fabric = createNode("legacy-1.20.2-fabric", 1_20_02, "mojang")
     Node mc_12004_fabric = createNode("legacy-1.20.4-fabric", 1_20_04, "mojang")
     Node mc_12006_fabric = createNode("legacy-1.20.6-fabric", 1_20_06, "mojang")
+    Node mc_12100_fabric = createNode("legacy-1.21.0-fabric", 1_21_00, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, file("versions/mapping-1.15.2-1.16.5.txt"))
@@ -35,4 +36,5 @@ preprocess {
     mc_12001_fabric.link(mc_12002_fabric, null)
     mc_12002_fabric.link(mc_12004_fabric, null)
     mc_12004_fabric.link(mc_12006_fabric, null)
+    mc_12006_fabric.link(mc_12100_fabric, null)
 }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/client/gui/MixinFont.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/minecraft/client/gui/MixinFont.java
@@ -1,6 +1,5 @@
 package top.hendrixshen.magiclib.mixin.compat.minecraft.client.gui;
 
-import com.mojang.blaze3d.vertex.Tesselator;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.Font;
@@ -14,10 +13,12 @@ import top.hendrixshen.magiclib.compat.minecraft.api.network.chat.ComponentCompa
 //#if MC > 11404
 import net.minecraft.client.renderer.MultiBufferSource;
 import top.hendrixshen.magiclib.util.MiscUtil;
+import top.hendrixshen.magiclib.util.minecraft.render.RenderUtil;
 //#else
 //$$ import com.mojang.blaze3d.platform.GlStateManager;
 //$$ import com.mojang.blaze3d.vertex.BufferBuilder;
 //$$ import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+//$$ import com.mojang.blaze3d.vertex.Tesselator;
 //$$ import org.lwjgl.opengl.GL11;
 //#endif
 
@@ -70,9 +71,8 @@ public abstract class MixinFont implements FontCompatApi {
 
     @Override
     public int drawInBatch(Component component, float x, float y, int color, boolean shadow, Matrix4f matrix4f, boolean seeThrough, int backgroundColor, int light) {
-        Tesselator tesselator = Tesselator.getInstance();
         //#if MC > 11404
-        MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediate(tesselator.getBuilder());
+        MultiBufferSource.BufferSource bufferSource = RenderUtil.getBufferSource();
         int ret = this.drawInBatch(
                 //#if MC > 11502
                 component,
@@ -97,6 +97,7 @@ public abstract class MixinFont implements FontCompatApi {
         //#else
         //$$ GlStateManager.pushMatrix();
         //$$ GlStateManager.multMatrix(matrix4f);
+        //$$
         //$$ if (seeThrough) {
         //$$     GlStateManager.depthMask(false);
         //$$     GlStateManager.disableDepthTest();
@@ -111,6 +112,7 @@ public abstract class MixinFont implements FontCompatApi {
         //$$ float g = (float) (backgroundColor >> 8 & 255) / 255.0F;
         //$$ float b = (float) (backgroundColor & 255) / 255.0F;
         //$$
+        //$$ Tesselator tesselator = Tesselator.getInstance();
         //$$ BufferBuilder bufferBuilder = tesselator.getBuilder();
         //$$ bufferBuilder.begin(GL11.GL_QUADS, DefaultVertexFormat.POSITION_COLOR);
         //$$ bufferBuilder.vertex(x - 1, y - 1, 0.01F).color(r, g, b, a).endVertex();
@@ -120,15 +122,18 @@ public abstract class MixinFont implements FontCompatApi {
         //$$ tesselator.end();
         //$$ GlStateManager.enableTexture();
         //$$ int ret;
+        //$$
         //$$ if (shadow) {
         //$$     ret = this.drawShadow(component.getColoredString(), x, y, color);
         //$$ } else {
         //$$     ret = this.draw(component.getColoredString(), x, y, color);
         //$$ }
+        //$$
         //$$ if (seeThrough) {
         //$$     GlStateManager.depthMask(true);
         //$$     GlStateManager.enableDepthTest();
         //$$ }
+        //$$
         //$$ GlStateManager.disableBlend();
         //$$ GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         //$$ GlStateManager.popMatrix();

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/event/render/MixinLevelRenderer.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/event/render/MixinLevelRenderer.java
@@ -17,6 +17,10 @@ import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.event.render.impl.RenderEventHandler;
 
+//#if MC > 12006
+//$$ import net.minecraft.client.DeltaTracker;
+//#endif
+
 /**
  * The implementation for mc [1.15.2, ~)
  */
@@ -39,11 +43,15 @@ public class MixinLevelRenderer {
             )
     )
     private void postRenderLevelNormal(
+            //#if MC > 12006
+            //$$ DeltaTracker deltaTracker,
+            //#else
             //#if MC < 12005
-            PoseStack poseStack,
+            PoseStack matrixStack,
             //#endif
             float tickDelta,
             long limitTime,
+            //#endif
             boolean renderBlockOutline,
             Camera camera,
             GameRenderer gameRenderer,
@@ -59,9 +67,13 @@ public class MixinLevelRenderer {
                 //#if MC > 12004
                 //$$ new PoseStack(),
                 //#else
-                poseStack,
+                matrixStack,
                 //#endif
+                //#if MC > 12006
+                //$$ deltaTracker.getGameTimeDeltaPartialTick(false)
+                //#else
                 tickDelta
+                //#endif
         );
     }
 
@@ -86,11 +98,15 @@ public class MixinLevelRenderer {
             )
     )
     private void postRenderLevelFabulous(
+            //#if MC > 12006
+            //$$ DeltaTracker deltaTracker,
+            //#else
             //#if MC < 12005
-            PoseStack poseStack,
+            PoseStack matrixStack,
             //#endif
             float tickDelta,
             long limitTime,
+            //#endif
             boolean renderBlockOutline,
             Camera camera,
             GameRenderer gameRenderer,
@@ -106,9 +122,13 @@ public class MixinLevelRenderer {
                 //#if MC > 12004
                 //$$ new PoseStack(),
                 //#else
-                poseStack,
+                matrixStack,
                 //#endif
+                //#if MC > 12006
+                //$$ deltaTracker.getGameTimeDeltaPartialTick(false)
+                //#else
                 tickDelta
+                //#endif
         );
     }
     //#endif

--- a/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
@@ -190,7 +190,6 @@ loom {
         runDir("run/server")
     }
 
-
     if (fabricLike) {
         runs {
             mixinAuditClient {
@@ -212,22 +211,25 @@ loom {
     // Setup client default settings.
     runClient {
         defaultCharacterEncoding("UTF-8")
-        file("${projectDir}/run/client/config").mkdirs()
-        file("${projectDir}/run/client/options.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("autoJump:false")
-                        writer.writeLine("enableVsync:false")
-                        writer.writeLine("forceUnicodeFont:true")
-                        writer.writeLine("fov:1.0")
-                        writer.writeLine("gamma:16.0")
-                        writer.writeLine("guiScale:3")
-                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                        writer.writeLine("maxFps:260")
-                        writer.writeLine("renderDistance:10")
-                        writer.writeLine("soundCategory_master:0.0")
+
+        doFirst {
+            file("${projectDir}/run/client/config").mkdirs()
+            file("${projectDir}/run/client/options.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("autoJump:false")
+                            writer.writeLine("enableVsync:false")
+                            writer.writeLine("forceUnicodeFont:true")
+                            writer.writeLine("fov:1.0")
+                            writer.writeLine("gamma:16.0")
+                            writer.writeLine("guiScale:3")
+                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                            writer.writeLine("maxFps:260")
+                            writer.writeLine("renderDistance:10")
+                            writer.writeLine("soundCategory_master:0.0")
+                        }
                     }
                 }
             }
@@ -238,24 +240,20 @@ loom {
     runServer {
         defaultCharacterEncoding("UTF-8")
 
-        // Agree eula before server init.
-        file("${projectDir}/run/server/eula.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                        writer.writeLine("#${new Date()}")
-                        writer.writeLine("eula=true")
+        doFirst {
+            // Agree eula before server init.
+            file("${projectDir}/run/server/eula.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                            writer.writeLine("#${new Date()}")
+                            writer.writeLine("eula=true")
+                        }
                     }
                 }
             }
-        }
-        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-            new File("${projectDir}/run/server").mkdirs()
-            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-            bufferedWriter.writeLine("eula=true")
-            bufferedWriter.close()
         }
     }
 }
@@ -446,11 +444,31 @@ tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     }
 }
 
+tasks.register("cleanRuns", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).parentFile.deleteDir()
+    }
+}
+
+tasks.register("cleanRunClient", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).deleteDir()
+    }
+}
+
+tasks.register("cleanRunServer", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.server.runDir).deleteDir()
+    }
+}
+
 [
+        "cleanRuns", "cleanRunClient", "cleanRunServer",
         "runClient", "runServer",
         "runMixinAuditClient", "runMixinAuditServer",
         "preprocessCode", "preprocessResources",
-        "preprocessTestCode", "preprocessTestResources"].forEach { taskName ->
+        "preprocessTestCode", "preprocessTestResources"
+].forEach { taskName ->
     if (tasks.getNames().contains(taskName)) {
         tasks.named(taskName) {
             it.group("${project.property("mod.id")}")

--- a/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
@@ -119,10 +119,14 @@ dependencies {
     apiDependencies.forEach { item ->
         String dependencyNotation = item[0]
         String dependencyVersion = project.findProperty("dependencies.api.${item[1]}_version")
-        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
+        boolean shouldResolve = item[2] && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
+            if (!dependencyVersion) {
+                throw new RuntimeException("Could not get unknown property 'dependencies.api.${item[1]}_version' for dependency ${item[0]} in project ${project.name}")
+            }
+
             modApi("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
@@ -133,10 +137,14 @@ dependencies {
     runtimeDependencies.forEach { item ->
         String dependencyNotation = item[0]
         String dependencyVersion = project.findProperty("dependencies.runtime.${item[1]}_version")
-        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
+        boolean shouldResolve = item[2] && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
+            if (!dependencyVersion) {
+                throw new RuntimeException("Could not get unknown property 'dependencies.api.${item[1]}_version' for dependency ${item[0]} in project ${project.name}")
+            }
+
             modRuntimeOnly("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }

--- a/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
@@ -84,6 +84,7 @@ def apiDependencies = [
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def runtimeDependencies = [
+        ["", "", false, false],
 ]
 
 dependencies {
@@ -121,12 +122,12 @@ dependencies {
     // API
     apiDependencies.forEach { item ->
         String dependencyNotation = item[0]
-        String propertyPrefix = item[1]
-        boolean shouldResolve = item[2]
+        String dependencyVersion = project.findProperty("dependencies.api.${item[1]}_version")
+        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
-            modApi("${dependencyNotation}:${project.property("dependencies.api.${propertyPrefix}_version")}") {
+            modApi("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
         }
@@ -135,12 +136,12 @@ dependencies {
     // Runtime Library - Make development environment comfortable.
     runtimeDependencies.forEach { item ->
         String dependencyNotation = item[0]
-        String propertyPrefix = item[1]
-        boolean shouldResolve = item[2]
+        String dependencyVersion = project.findProperty("dependencies.runtime.${item[1]}_version")
+        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
-            modRuntimeOnly("${dependencyNotation}:${project.property("dependencies.runtime.${propertyPrefix}_version")}") {
+            modRuntimeOnly("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
         }

--- a/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.14.4-fabric/build.gradle
@@ -68,10 +68,6 @@ repositories {
     maven {
         name("Jitpack Maven")
         url("https://jitpack.io")
-
-        content {
-            includeGroup("com.github.Nyan-Work")
-        }
     }
 
     mavenCentral()
@@ -186,71 +182,72 @@ loom {
         runDir("run/server")
     }
 
-    runs {
-        mixinAuditClient {
-            inherit(client)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/client")
-        }
 
-        mixinAuditServer {
-            inherit(server)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/server")
+    if (fabricLike) {
+        runs {
+            mixinAuditClient {
+                inherit(client)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/client")
+            }
+
+            mixinAuditServer {
+                inherit(server)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/server")
+            }
         }
     }
 
-    if (fabricLike) {
-        // Setup client default settings.
-        runClient {
-            defaultCharacterEncoding("UTF-8")
-            file("${projectDir}/run/client/config").mkdirs()
-            file("${projectDir}/run/client/options.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("autoJump:false")
-                            writer.writeLine("enableVsync:false")
-                            writer.writeLine("forceUnicodeFont:true")
-                            writer.writeLine("fov:1.0")
-                            writer.writeLine("gamma:16.0")
-                            writer.writeLine("guiScale:3")
-                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                            writer.writeLine("maxFps:260")
-                            writer.writeLine("renderDistance:10")
-                            writer.writeLine("soundCategory_master:0.0")
-                        }
+    // Setup client default settings.
+    runClient {
+        defaultCharacterEncoding("UTF-8")
+        file("${projectDir}/run/client/config").mkdirs()
+        file("${projectDir}/run/client/options.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("autoJump:false")
+                        writer.writeLine("enableVsync:false")
+                        writer.writeLine("forceUnicodeFont:true")
+                        writer.writeLine("fov:1.0")
+                        writer.writeLine("gamma:16.0")
+                        writer.writeLine("guiScale:3")
+                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                        writer.writeLine("maxFps:260")
+                        writer.writeLine("renderDistance:10")
+                        writer.writeLine("soundCategory_master:0.0")
                     }
                 }
             }
         }
+    }
 
-        // Setup server default settings.
-        runServer {
-            defaultCharacterEncoding("UTF-8")
+    // Setup server default settings.
+    runServer {
+        defaultCharacterEncoding("UTF-8")
 
-            // Agree eula before server init.
-            file("${projectDir}/run/server/eula.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                            writer.writeLine("#${new Date()}")
-                            writer.writeLine("eula=true")
-                        }
+        // Agree eula before server init.
+        file("${projectDir}/run/server/eula.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                        writer.writeLine("#${new Date()}")
+                        writer.writeLine("eula=true")
                     }
                 }
             }
-            if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-                new File("${projectDir}/run/server").mkdirs()
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-                bufferedWriter.writeLine("eula=true")
-                bufferedWriter.close()
-            }
+        }
+        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
+            new File("${projectDir}/run/server").mkdirs()
+            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
+            bufferedWriter.writeLine("eula=true")
+            bufferedWriter.close()
         }
     }
 }

--- a/magiclib-legacy-compat/versions/1.21.0-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.21.0-fabric/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21- <1.21.1-
+dependencies.minecraft_version=1.21
+
+# Carpet - 1.4.141+v240429
+# fabric-carpet-1.21-1.4.147+v240613.jar
+dependencies.api.carpet_version=1.21-1.4.147+v240613
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-legacy-compat/versions/1.21.0-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
+++ b/magiclib-legacy-compat/versions/1.21.0-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/build.gradle
+++ b/magiclib-malilib-extra/build.gradle
@@ -41,14 +41,16 @@ preprocess {
     // Forge
     Node mc_11701_forge = createNode("malilib-1.17.1-forge", 1_17_01, "mojang")
     Node mc_11802_forge = createNode("malilib-1.18.2-forge", 1_18_02, "mojang")
-    Node mc_11804_forge = createNode("malilib-1.19.4-forge", 1_19_04, "mojang")
+    Node mc_11904_forge = createNode("malilib-1.19.4-forge", 1_19_04, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, null)
     mc_11802_fabric.link(mc_11802_forge, null)
-    mc_11904_fabric.link(mc_11804_forge, null)
+    mc_11904_fabric.link(mc_11904_forge, null)
 
     // NeoForge
     Node mc_12006_neoforge = createNode("malilib-1.20.6-neoforge", 1_20_06, "mojang")
+    Node mc_12100_neoforge = createNode("malilib-1.21.0-neoforge", 1_21_00, "mojang")
 
     mc_12006_fabric.link(mc_12006_neoforge, null)
+    mc_12100_fabric.link(mc_12100_neoforge, null)
 }

--- a/magiclib-malilib-extra/build.gradle
+++ b/magiclib-malilib-extra/build.gradle
@@ -23,6 +23,7 @@ preprocess {
     Node mc_12002_fabric = createNode("malilib-1.20.2-fabric", 1_20_02, "mojang")
     Node mc_12004_fabric = createNode("malilib-1.20.4-fabric", 1_20_04, "mojang")
     Node mc_12006_fabric = createNode("malilib-1.20.6-fabric", 1_20_06, "mojang")
+    Node mc_12100_fabric = createNode("malilib-1.21.0-fabric", 1_21_00, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, null)
@@ -35,6 +36,7 @@ preprocess {
     mc_12001_fabric.link(mc_12002_fabric, null)
     mc_12002_fabric.link(mc_12004_fabric, null)
     mc_12004_fabric.link(mc_12006_fabric, null)
+    mc_12006_fabric.link(mc_12100_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("malilib-1.17.1-forge", 1_17_01, "mojang")

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
@@ -7,7 +7,9 @@ import fi.dy.masa.malilib.hotkeys.IKeybindProvider;
 import top.hendrixshen.magiclib.impl.malilib.SharedConstants;
 
 //#if FORGE_LIKE
-//#if MC > 11701 && MC != 11904
+//#if MC > 12006
+//$$ import org.thinkingstudio.mafglib.util.NeoUtils;
+//#elseif MC > 11701 && MC != 11904
 //$$ import org.thinkingstudio.mafglib.util.ForgePlatformUtils;
 //#else
 //$$ import fi.dy.masa.malilib.compat.forge.ForgePlatformCompat;
@@ -30,7 +32,9 @@ public class MalilibStuffsInitializer {
 
     //#if FORGE_LIKE
     //$$ private static void setupForgeConfigGui() {
-    //#if MC > 11701 && MC != 11904
+    //#if MC > 12006
+    //$$     NeoUtils.getInstance().registerModConfigScreen(SharedConstants.getModIdentifier(),
+    //#elseif MC > 11701 && MC != 11904
     //$$     ForgePlatformUtils.getInstance().registerModConfigScreen(SharedConstants.getModIdentifier(),
     //#else
     //$$     ForgePlatformCompat.getInstance()

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/MagicConfigManagerImpl.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/MagicConfigManagerImpl.java
@@ -56,7 +56,7 @@ public class MagicConfigManagerImpl implements MagicConfigManager, IKeybindProvi
                 Object config = field.get(null);
 
                 if (!(config instanceof MagicIConfigBase)) {
-                    MagicLib.getLogger().warn("{} is not a subclass of MagicIConfigBase, skipping!", config);
+                    MagicLib.getLogger().warn("{} is not a subclass of MagicIConfigBase, skipping!", field.getName());
                     continue;
                 }
 

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigBoolean.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigBoolean.java
@@ -20,6 +20,11 @@ public class MagicConfigBoolean extends ConfigBoolean implements MagicIConfigBas
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         boolean oldValue = this.getBooleanValue();
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigBooleanHotkeyed.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigBooleanHotkeyed.java
@@ -33,6 +33,11 @@ public class MagicConfigBooleanHotkeyed extends ConfigBooleanHotkeyed implements
         return MagicIConfigBase.super.getPrettyName();
     }
 
+    @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
     /**
      * Use this instead of {@code getKeybind().setCallback} directly
      * So the config statistic can be updated correctly

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigColor.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigColor.java
@@ -23,6 +23,11 @@ public class MagicConfigColor extends ConfigColor implements MagicIConfigBase {
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         Color4f oldValue = this.getColor();
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigDouble.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigDouble.java
@@ -34,6 +34,11 @@ public class MagicConfigDouble extends ConfigDouble implements MagicIConfigBase 
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         double oldValue = this.getDoubleValue();
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigHotkey.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigHotkey.java
@@ -28,6 +28,11 @@ public class MagicConfigHotkey extends ConfigHotkey implements MagicIConfigBase 
         return MagicIConfigBase.super.getPrettyName();
     }
 
+    @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
     /**
      * Use this instead of {@code getKeybind().setCallback} directly
      * So the config statistic can be updated correctly

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigInteger.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigInteger.java
@@ -34,6 +34,11 @@ public class MagicConfigInteger extends ConfigInteger implements MagicIConfigBas
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         int oldValue = this.getIntegerValue();
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigOptionList.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigOptionList.java
@@ -21,6 +21,11 @@ public class MagicConfigOptionList extends ConfigOptionList implements MagicICon
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         IConfigOptionListEntry oldValue = this.getOptionListValue();
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigString.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigString.java
@@ -22,6 +22,11 @@ public class MagicConfigString extends ConfigString implements MagicIConfigBase 
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         String oldValue = this.getStringValue();
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigStringList.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigStringList.java
@@ -24,6 +24,11 @@ public class MagicConfigStringList extends ConfigStringList implements MagicICon
     }
 
     @Override
+    public String getConfigGuiDisplayName() {
+        return MagicIConfigBase.super.getConfigGuiDisplayName();
+    }
+
+    @Override
     public void setValueFromJsonElement(JsonElement element) {
         List<String> oldValue = Lists.newArrayList(this.getStrings());
         super.setValueFromJsonElement(element);

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
@@ -24,6 +24,7 @@ import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
 @Dependencies(
         require = {
                 @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib"),
+                @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<1.21"),
                 @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
                 @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
         },

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -123,10 +123,14 @@ dependencies {
     apiDependencies.forEach { item ->
         String dependencyNotation = item[0]
         String dependencyVersion = project.findProperty("dependencies.api.${item[1]}_version")
-        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
+        boolean shouldResolve = item[2] && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
+            if (!dependencyVersion) {
+                throw new RuntimeException("Could not get unknown property 'dependencies.api.${item[1]}_version' for dependency ${item[0]} in project ${project.name}")
+            }
+
             modApi("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
@@ -137,10 +141,14 @@ dependencies {
     runtimeDependencies.forEach { item ->
         String dependencyNotation = item[0]
         String dependencyVersion = project.findProperty("dependencies.runtime.${item[1]}_version")
-        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
+        boolean shouldResolve = item[2] && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
+            if (!dependencyVersion) {
+                throw new RuntimeException("Could not get unknown property 'dependencies.api.${item[1]}_version' for dependency ${item[0]} in project ${project.name}")
+            }
+
             modRuntimeOnly("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -186,71 +186,72 @@ loom {
         runDir("run/server")
     }
 
-    runs {
-        mixinAuditClient {
-            inherit(client)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/client")
-        }
+    if (fabricLike) {
+        runs {
+            mixinAuditClient {
+                inherit(client)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/client")
+            }
 
-        mixinAuditServer {
-            inherit(server)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/server")
+            mixinAuditServer {
+                inherit(server)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/server")
+            }
         }
     }
 
-    if (fabricLike) {
-        // Setup client default settings.
-        runClient {
-            defaultCharacterEncoding("UTF-8")
-            file("${projectDir}/run/client/config").mkdirs()
-            file("${projectDir}/run/client/options.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("autoJump:false")
-                            writer.writeLine("enableVsync:false")
-                            writer.writeLine("forceUnicodeFont:true")
-                            writer.writeLine("fov:1.0")
-                            writer.writeLine("gamma:16.0")
-                            writer.writeLine("guiScale:3")
-                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                            writer.writeLine("maxFps:260")
-                            writer.writeLine("renderDistance:10")
-                            writer.writeLine("soundCategory_master:0.0")
-                        }
+    // Setup client default settings.
+    runClient {
+        defaultCharacterEncoding("UTF-8")
+        file("${projectDir}/run/client/config").mkdirs()
+        file("${projectDir}/run/client/options.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("autoJump:false")
+                        writer.writeLine("enableVsync:false")
+                        writer.writeLine("forceUnicodeFont:true")
+                        writer.writeLine("fov:1.0")
+                        writer.writeLine("gamma:16.0")
+                        writer.writeLine("guiScale:3")
+                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                        writer.writeLine("maxFps:260")
+                        writer.writeLine("renderDistance:10")
+                        writer.writeLine("soundCategory_master:0.0")
+                    }
+                }
+            }
+        }
+    }
+
+    // Setup server default settings.
+    runServer {
+        defaultCharacterEncoding("UTF-8")
+
+        // Agree eula before server init.
+        file("${projectDir}/run/server/eula.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                        writer.writeLine("#${new Date()}")
+                        writer.writeLine("eula=true")
                     }
                 }
             }
         }
 
-        // Setup server default settings.
-        runServer {
-            defaultCharacterEncoding("UTF-8")
-
-            // Agree eula before server init.
-            file("${projectDir}/run/server/eula.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                            writer.writeLine("#${new Date()}")
-                            writer.writeLine("eula=true")
-                        }
-                    }
-                }
-            }
-            if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-                new File("${projectDir}/run/server").mkdirs()
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-                bufferedWriter.writeLine("eula=true")
-                bufferedWriter.close()
-            }
+        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
+            new File("${projectDir}/run/server").mkdirs()
+            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
+            bufferedWriter.writeLine("eula=true")
+            bufferedWriter.close()
         }
     }
 }

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -215,22 +215,25 @@ loom {
     // Setup client default settings.
     runClient {
         defaultCharacterEncoding("UTF-8")
-        file("${projectDir}/run/client/config").mkdirs()
-        file("${projectDir}/run/client/options.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("autoJump:false")
-                        writer.writeLine("enableVsync:false")
-                        writer.writeLine("forceUnicodeFont:true")
-                        writer.writeLine("fov:1.0")
-                        writer.writeLine("gamma:16.0")
-                        writer.writeLine("guiScale:3")
-                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                        writer.writeLine("maxFps:260")
-                        writer.writeLine("renderDistance:10")
-                        writer.writeLine("soundCategory_master:0.0")
+
+        doFirst {
+            file("${projectDir}/run/client/config").mkdirs()
+            file("${projectDir}/run/client/options.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("autoJump:false")
+                            writer.writeLine("enableVsync:false")
+                            writer.writeLine("forceUnicodeFont:true")
+                            writer.writeLine("fov:1.0")
+                            writer.writeLine("gamma:16.0")
+                            writer.writeLine("guiScale:3")
+                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                            writer.writeLine("maxFps:260")
+                            writer.writeLine("renderDistance:10")
+                            writer.writeLine("soundCategory_master:0.0")
+                        }
                     }
                 }
             }
@@ -241,25 +244,20 @@ loom {
     runServer {
         defaultCharacterEncoding("UTF-8")
 
-        // Agree eula before server init.
-        file("${projectDir}/run/server/eula.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                        writer.writeLine("#${new Date()}")
-                        writer.writeLine("eula=true")
+        doFirst {
+            // Agree eula before server init.
+            file("${projectDir}/run/server/eula.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                            writer.writeLine("#${new Date()}")
+                            writer.writeLine("eula=true")
+                        }
                     }
                 }
             }
-        }
-
-        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-            new File("${projectDir}/run/server").mkdirs()
-            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-            bufferedWriter.writeLine("eula=true")
-            bufferedWriter.close()
         }
     }
 }
@@ -456,11 +454,31 @@ tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     }
 }
 
+tasks.register("cleanRuns", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).parentFile.deleteDir()
+    }
+}
+
+tasks.register("cleanRunClient", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).deleteDir()
+    }
+}
+
+tasks.register("cleanRunServer", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.server.runDir).deleteDir()
+    }
+}
+
 [
+        "cleanRuns", "cleanRunClient", "cleanRunServer",
         "runClient", "runServer",
         "runMixinAuditClient", "runMixinAuditServer",
         "preprocessCode", "preprocessResources",
-        "preprocessTestCode", "preprocessTestResources"].forEach { taskName ->
+        "preprocessTestCode", "preprocessTestResources"
+].forEach { taskName ->
     if (tasks.getNames().contains(taskName)) {
         tasks.named(taskName) {
             it.group("${project.property("mod.id")}")

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -80,6 +80,7 @@ def apiDependencies = [
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def runtimeDependencies = [
+        ["", "", false, false],
 ]
 
 dependencies {
@@ -120,12 +121,12 @@ dependencies {
     // API
     apiDependencies.forEach { item ->
         String dependencyNotation = item[0]
-        String propertyPrefix = item[1]
-        boolean shouldResolve = item[2]
+        String dependencyVersion = project.findProperty("dependencies.api.${item[1]}_version")
+        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
-            modApi("${dependencyNotation}:${project.property("dependencies.api.${propertyPrefix}_version")}") {
+            modApi("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
         }
@@ -134,12 +135,12 @@ dependencies {
     // Runtime Library - Make development environment comfortable.
     runtimeDependencies.forEach { item ->
         String dependencyNotation = item[0]
-        String propertyPrefix = item[1]
-        boolean shouldResolve = item[2]
+        String dependencyVersion = project.findProperty("dependencies.runtime.${item[1]}_version")
+        boolean shouldResolve = item[2] && dependencyVersion && dependencyVersion != "0"
         boolean shouldTransitive = item[3]
 
         if (shouldResolve) {
-            modRuntimeOnly("${dependencyNotation}:${project.property("dependencies.runtime.${propertyPrefix}_version")}") {
+            modRuntimeOnly("${dependencyNotation}:${dependencyVersion}") {
                 transitive(shouldTransitive)
             }
         }

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -73,9 +73,10 @@ repositories {
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def apiDependencies = [
-        ["maven.modrinth:malilib"         , "malilib", fabricLike && mcVersion < 12100, false],
-        ["com.github.sakura-ryoko:malilib", "malilib", fabricLike && mcVersion > 12006, false],
-        ["maven.modrinth:mafglib"         , "malilib", forgeLike                      , false],
+        ["maven.modrinth:malilib"         , "malilib"   , fabricLike && mcVersion < 12100, false],
+        ["com.github.sakura-ryoko:malilib", "malilib"   , fabricLike && mcVersion > 12006, false],
+        ["maven.modrinth:mafglib"         , "malilib"   , forgeLike                      , false],
+        ["maven.modrinth:neonetwork"      , "neonetwork", forgeLike && mcVersion > 12004 , false],
 ]
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.

--- a/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
@@ -7,6 +7,10 @@ dependencies.minecraft_version=1.20.6
 # MaFgLib-0.1.7-mc1.20.6.jar
 dependencies.api.malilib_version=0.1.7-mc1.20.6
 
+# NeoNetwork 0.1.5
+# NeoNetwork-0.1.5+mc1.20.6.jar
+dependencies.api.neonetwork_version=0.1.5+mc1.20.6
+
 # Loom Properties
 loom.platform=neoforge
 

--- a/magiclib-malilib-extra/versions/1.21.0-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-fabric/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21- <1.21.1-
+dependencies.minecraft_version=1.21
+
+# Malilib 1.21-sakura.12
+# malilib-dc2525e2ee.jar
+dependencies.api.malilib_version=dc2525e2ee
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-malilib-extra/versions/1.21.0-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.21.0-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
@@ -7,6 +7,10 @@ dependencies.minecraft_version=1.21
 # MaFgLib-0.1.14-mc1.21.jar
 dependencies.api.malilib_version=0.1.14-mc1.21
 
+# NeoNetwork 0.1.5
+# NeoNetwork-0.1.5+mc1.21.jar
+dependencies.api.neonetwork_version=0.1.5+mc1.21
+
 # Loom Properties
 loom.platform=neoforge
 

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
@@ -1,0 +1,14 @@
+# Dependency Versions
+dependencies.neoforge_version=21.0.78-beta
+dependencies.minecraft_dependency=1.21
+dependencies.minecraft_version=1.21
+
+# Malilib 0.1.14
+# MaFgLib-0.1.14-mc1.21.jar
+dependencies.api.malilib_version=0.1.14-mc1.21
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -23,6 +23,7 @@ preprocess {
     Node mc_12002_fabric = createNode("mc-api-1.20.2-fabric", 1_20_02, "mojang")
     Node mc_12004_fabric = createNode("mc-api-1.20.4-fabric", 1_20_04, "mojang")
     Node mc_12006_fabric = createNode("mc-api-1.20.6-fabric", 1_20_06, "mojang")
+    Node mc_12100_fabric = createNode("mc-api-1.21.0-fabric", 1_21_00, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, file("versions/mapping-fabric-1.14.4-1.15.2.txt"))
     mc_11502_fabric.link(mc_11605_fabric, file("versions/mapping-fabric-1.15.2-1.16.5.txt"))
@@ -35,6 +36,7 @@ preprocess {
     mc_12001_fabric.link(mc_12002_fabric, null)
     mc_12002_fabric.link(mc_12004_fabric, null)
     mc_12004_fabric.link(mc_12006_fabric, null)
+    mc_12006_fabric.link(mc_12100_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("mc-api-1.17.1-forge", 1_17_01, "mojang")

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -50,7 +50,9 @@ preprocess {
     // NeoForge
     Node mc_12002_neoforge = createNode("mc-api-1.20.2-neoforge", 1_20_02, "mojang")
     Node mc_12006_neoforge = createNode("mc-api-1.20.6-neoforge", 1_20_06, "mojang")
+    Node mc_12100_neoforge = createNode("mc-api-1.21.0-neoforge", 1_21_00, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
     mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
+    mc_12100_fabric.link(mc_12100_neoforge, file("versions/mapping-1.21.0-fabric-neoforge.txt"))
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/MutableComponentCompat.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/MutableComponentCompat.java
@@ -49,7 +49,7 @@ public interface MutableComponentCompat extends ComponentCompat {
     }
 
     default MutableComponentCompat withStyle(ChatFormatting... chatFormattings) {
-        this.getStyle().applyFormats(chatFormattings);
+        this.setStyle(this.getStyle().applyFormats(chatFormattings));
         return this;
     }
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/resources/ResourceLocationCompat.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/resources/ResourceLocationCompat.java
@@ -1,0 +1,23 @@
+package top.hendrixshen.magiclib.api.compat.minecraft.resources;
+
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import top.hendrixshen.magiclib.util.collect.Provider;
+
+public interface ResourceLocationCompat extends Provider<ResourceLocation> {
+    static @NotNull ResourceLocation fromNamespaceAndPath(String namespace, String path) {
+        //#if MC > 12006
+        //$$ return ResourceLocation.fromNamespaceAndPath(namespace, path);
+        //#else
+        return new ResourceLocation(namespace, path);
+        //#endif
+    }
+
+    static @NotNull ResourceLocation withDefaultNamespace(String path) {
+        //#if MC > 12006
+        //$$ return ResourceLocation.withDefaultNamespace(path);
+        //#else
+        return new ResourceLocation(path);
+        //#endif
+    }
+}

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/render/context/RenderContext.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/render/context/RenderContext.java
@@ -23,13 +23,18 @@ package top.hendrixshen.magiclib.api.render.context;
 import com.mojang.math.Matrix4f;
 import net.minecraft.client.gui.GuiComponent;
 import org.jetbrains.annotations.NotNull;
+import top.hendrixshen.magiclib.api.render.matrix.MatrixStack;
+import top.hendrixshen.magiclib.impl.render.context.LevelRenderContextImpl;
 import top.hendrixshen.magiclib.impl.render.context.RenderContextImpl;
+import top.hendrixshen.magiclib.impl.render.matrix.MinecraftPoseStack;
+
+//#if MC > 12004
+//$$ import org.joml.Matrix4fStack;
+//$$ import top.hendrixshen.magiclib.impl.render.matrix.JomlMatrixStack;
+//#endif
 
 //#if MC > 11904
-//$$ import com.mojang.blaze3d.vertex.Tesselator;
-//$$ import net.minecraft.client.Minecraft;
-//$$ import net.minecraft.client.renderer.MultiBufferSource;
-//$$ import top.hendrixshen.magiclib.mixin.minecraft.accessor.GuiGraphicsAccessor;
+//$$ import top.hendrixshen.magiclib.util.minecraft.render.RenderContextUtil;
 //#endif
 
 //#if MC > 11502
@@ -37,7 +42,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 //#endif
 
 /**
- * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/10e1a937aadcefb1f2d9d9bab8badc873d4a5b3d/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderContext.java">TweakerMore</a>
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/e8edce20f53a1062c570af99a740fb6db0e73447/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderContext.java">TweakerMore</a>
  */
 public interface RenderContext {
     static @NotNull RenderContext of(
@@ -45,37 +50,68 @@ public interface RenderContext {
             @NotNull PoseStack poseStack
             //#endif
     ) {
-        //#if MC > 11904
-        //$$ GuiGraphics guiGraphics = new GuiGraphics(Minecraft.getInstance(),
-        //$$         MultiBufferSource.immediate(Tesselator.getInstance().getBuilder()));
-        //$$ ((GuiGraphicsAccessor) guiGraphics).magiclib$setPose(poseStack);
-        //#endif
-
         return new RenderContextImpl(
                 //#if MC > 11904
-                //$$ guiGraphics,
+                //$$ RenderContextUtil.createDrawContext(poseStack),
                 //#endif
-                //#if MC > 11502
-                poseStack
+                new MinecraftPoseStack(
+                        //#if MC > 11502
+                        poseStack
+                        //#endif
+                )
+        );
+    }
+
+    static @NotNull LevelRenderContextImpl createWorldRenderContext(
+            //#if MC > 12004
+            //$$ @NotNull Matrix4fStack matrixStack
+            //#elseif MC > 11502
+            @NotNull PoseStack matrixStack
+            //#endif
+    ) {
+        return new LevelRenderContextImpl(
+                //#if MC > 11904
+                //$$ RenderContextUtil.createDrawContext(
+                //#if MC > 12004
+                //$$         new PoseStack()
+                //#else
+                //$$         matrixStack
+                //#endif
+                //$$ ),
+                //#endif
+                //#if MC > 12004
+                //$$ new JomlMatrixStack(matrixStack)
+                //#else
+                new MinecraftPoseStack(
+                        //#if MC > 11502
+                        matrixStack
+                        //#endif
+                )
                 //#endif
         );
     }
 
+    //#if MC > 12004
+    //$$ static RenderContext of(@NotNull Matrix4fStack matrixStack) {
+    //$$     return new RenderContextImpl(RenderContextUtil.createDrawContext(new PoseStack()), new JomlMatrixStack(matrixStack));
+    //$$ }
+    //#endif
+
     //#if MC > 11904
     //$$ static RenderContext of(@NotNull GuiGraphics guiGraphics) {
-    //$$ 	return new RenderContextImpl(guiGraphics, guiGraphics.pose());
+    //$$ 	return new RenderContextImpl(guiGraphics, new MinecraftPoseStack(guiGraphics.pose()));
     //$$ }
     //#endif
 
     GuiComponent getGuiComponent();
 
     //#if MC > 11502
-    PoseStack getPoseStack();
+    MatrixStack getMatrixStack();
     //#endif
 
-    void pushPose();
+    void pushMatrix();
 
-    void popPose();
+    void popMatrix();
 
     void translate(double x, double y, double z);
 

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/render/matrix/MatrixStack.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/render/matrix/MatrixStack.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2023  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.hendrixshen.magiclib.api.render.matrix;
+
+import com.mojang.math.Matrix4f;
+
+//#if MC > 11404
+import com.mojang.blaze3d.vertex.PoseStack;
+//#endif
+
+/**
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/6b126681084526b295e268330ca9053dda3b63a9/src/main/java/me/fallenbreath/tweakermore/util/render/matrix/IMatrixStack.java">TweakerMore</a>
+ */
+public interface MatrixStack {
+    //#if MC > 11404
+    PoseStack getPoseStack();
+    //#endif
+
+    void pushMatrix();
+
+    void popMatrix();
+
+    void translate(double x, double y, double z);
+
+    void scale(double x, double y, double z);
+
+    void mulMatrix(Matrix4f matrix4f);
+}

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/event/minecraft/render/RenderLevelEvent.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/event/minecraft/render/RenderLevelEvent.java
@@ -11,7 +11,9 @@ import top.hendrixshen.magiclib.api.render.context.RenderContext;
 
 import java.util.List;
 
-//#if MC > 11502
+//#if MC > 12004
+//$$ import org.joml.Matrix4fStack;
+//#elseif MC > 11502
 import com.mojang.blaze3d.vertex.PoseStack;
 //#endif
 
@@ -26,14 +28,16 @@ public class RenderLevelEvent {
 
         public static @NotNull LevelRenderContext of(
                 ClientLevel level,
-                //#if MC > 11502
-                PoseStack poseStack,
+                //#if MC > 12004
+                //$$ @NotNull Matrix4fStack matrixStack,
+                //#elseif MC > 11502
+                @NotNull PoseStack matrixStack,
                 //#endif
                 float partialTicks
         ) {
-            return new LevelRenderContext(level, RenderContext.of(
+            return new LevelRenderContext(level, RenderContext.createWorldRenderContext(
                     //#if MC > 11502
-                    poseStack
+                    matrixStack
                     //#endif
             ), partialTicks);
         }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/CameraPositionTransformer.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/CameraPositionTransformer.java
@@ -58,7 +58,7 @@ public class CameraPositionTransformer {
         Minecraft mc = Minecraft.getInstance();
         Camera camera = mc.gameRenderer.getMainCamera();
         Vec3 vec3 = this.pos.subtract(camera.getPosition());
-        context.pushPose();
+        context.pushMatrix();
         context.translate(vec3.x(), vec3.y(), vec3.z());
         //#if MC > 11404
         context.mulPoseMatrix(
@@ -83,7 +83,7 @@ public class CameraPositionTransformer {
             throw new RuntimeException("CameraPositionTransformer: Calling restore before calling apply");
         }
 
-        this.context.popPose();
+        this.context.popMatrix();
         this.context = null;
     }
 

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/Scaler.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/Scaler.java
@@ -55,7 +55,7 @@ public class Scaler {
      */
     public void apply(RenderContext context) {
         this.context = context;
-        this.context.pushPose();
+        this.context.pushMatrix();
         this.context.translate(-anchorX * factor, -anchorY * factor, 0);
         this.context.scale(factor, factor, 1);
         this.context.translate(anchorX / factor, anchorY / factor, 0);
@@ -69,7 +69,7 @@ public class Scaler {
             throw new RuntimeException("Scaler: Calling restore before calling apply");
         }
 
-        this.context.popPose();
+        this.context.popMatrix();
     }
 
     public RenderContext getRenderContext() {

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/context/LevelRenderContextImpl.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/context/LevelRenderContextImpl.java
@@ -1,0 +1,33 @@
+package top.hendrixshen.magiclib.impl.render.context;
+
+import org.jetbrains.annotations.NotNull;
+
+//#if MC > 12004
+//$$ import top.hendrixshen.magiclib.impl.render.matrix.JomlMatrixStack;
+//#else
+import top.hendrixshen.magiclib.impl.render.matrix.MinecraftPoseStack;
+//#endif
+
+//#if MC > 11904
+//$$ import net.minecraft.client.gui.GuiGraphics;
+//#endif
+
+public class LevelRenderContextImpl extends RenderContextImpl {
+    public LevelRenderContextImpl(
+            //#if MC > 11904
+            //$$ GuiGraphics guiGraphics,
+            //#endif
+            //#if MC > 12004
+            //$$ @NotNull JomlMatrixStack matrixStack
+            //#else
+            @NotNull MinecraftPoseStack matrixStack
+            //#endif
+    ) {
+        super(
+                //#if MC > 11904
+                //$$ guiGraphics,
+                //#endif
+                matrixStack
+        );
+    }
+}

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/context/RenderContextImpl.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/context/RenderContextImpl.java
@@ -20,48 +20,43 @@
 
 package top.hendrixshen.magiclib.impl.render.context;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.math.Matrix4f;
 import net.minecraft.client.gui.GuiComponent;
 import top.hendrixshen.magiclib.api.render.context.RenderContext;
+import top.hendrixshen.magiclib.api.render.matrix.MatrixStack;
+import org.jetbrains.annotations.NotNull;
+
+//#if MC > 12004
+//$$ import top.hendrixshen.magiclib.impl.render.matrix.JomlMatrixStack;
+//$$ import org.joml.Matrix4fStack;
+//#endif
 
 //#if MC > 11502
-import com.mojang.blaze3d.vertex.PoseStack;
-import org.jetbrains.annotations.NotNull;
-//#else
-//$$ import com.mojang.blaze3d.platform.GlStateManager;
+//$$ import com.mojang.blaze3d.vertex.PoseStack;
+//$$ import org.jetbrains.annotations.NotNull;
 //#endif
 
 /**
- * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/10e1a937aadcefb1f2d9d9bab8badc873d4a5b3d/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderContextImpl.java">TweakerMore</a>
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/e8edce20f53a1062c570af99a740fb6db0e73447/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderContextImpl.java">TweakerMore</a>
  */
-//#if MC > 11502 && MC < 11700
-@SuppressWarnings("deprecation")
-//#endif
 public class RenderContextImpl implements RenderContext {
     //#if MC > 11904
     //$$ private final GuiGraphics guiGraphics;
     //#endif
 
-    //#if MC > 11502
     @NotNull
-    private final PoseStack poseStack;
-    //#endif
+    private final MatrixStack matrixStack;
 
     public RenderContextImpl(
             //#if MC > 11904
             //$$ GuiGraphics guiGraphics,
             //#endif
-            //#if MC > 11502
-            @NotNull PoseStack poseStack
-            //#endif
+            @NotNull MatrixStack matrixStack
     ) {
         //#if MC > 11904
         //$$ this.guiGraphics = guiGraphics;
         //#endif
-        //#if MC > 11502
-        this.poseStack = poseStack;
-        //#endif
+        this.matrixStack = matrixStack;
     }
 
     @Override
@@ -76,63 +71,33 @@ public class RenderContextImpl implements RenderContext {
 
     //#if MC > 11502
     @Override
-    public @NotNull PoseStack getPoseStack() {
-        return this.poseStack;
+    public @NotNull MatrixStack getMatrixStack() {
+        return this.matrixStack;
     }
     //#endif
 
     @Override
-    public void pushPose() {
-        //#if MC > 11605
-        //$$ this.poseStack.pushPose();
-        //#elseif MC > 11404
-        RenderSystem.pushMatrix();
-        //#else
-        //$$ GlStateManager.pushMatrix();
-        //#endif
+    public void pushMatrix() {
+        this.matrixStack.pushMatrix();
     }
 
     @Override
-    public void popPose() {
-        //#if MC > 11605
-        //$$ this.poseStack.popPose();
-        //#elseif MC > 11404
-        RenderSystem.pushMatrix();
-        //#else
-        //$$ GlStateManager.popMatrix();
-        //#endif
+    public void popMatrix() {
+        this.matrixStack.popMatrix();
     }
 
     @Override
     public void translate(double x, double y, double z) {
-        //#if MC > 11605
-        //$$ this.poseStack.translate(x, y, z);
-        //#elseif MC > 11404
-        RenderSystem.translated(x, y, z);
-        //#else
-        //$$ GlStateManager.translated(x, y, z);
-        //#endif
+        this.matrixStack.translate(x, y, z);
     }
 
     @Override
     public void scale(double x, double y, double z) {
-        //#if MC > 11605
-        //$$ this.poseStack.scale((float) x, (float) y, (float) z);
-        //#elseif MC > 11404
-        RenderSystem.scaled(x, y, z);
-        //#else
-        //$$ GlStateManager.scaled(x, y, z);
-        //#endif
+        this.matrixStack.scale(x, y, z);
     }
 
     @Override
     public void mulPoseMatrix(Matrix4f matrix4f) {
-        //#if MC > 11605
-        //$$ this.poseStack.mulPoseMatrix(matrix4f);
-        //#elseif MC > 11404
-        RenderSystem.multMatrix(matrix4f);
-        //#else
-        //$$ GlStateManager.multMatrix(matrix4f);
-        //#endif
+        this.matrixStack.mulMatrix(matrix4f);
     }
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/JomlMatrixStack.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/JomlMatrixStack.java
@@ -1,0 +1,6 @@
+package top.hendrixshen.magiclib.impl.render.matrix;
+
+import top.hendrixshen.magiclib.api.render.matrix.MatrixStack;
+
+public abstract class JomlMatrixStack implements MatrixStack {
+}

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/MinecraftPoseStack.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/MinecraftPoseStack.java
@@ -70,7 +70,7 @@ public class MinecraftPoseStack implements MatrixStack {
         //#if MC > 11605
         //$$ this.poseStack.popPose();
         //#elseif MC > 11404
-        RenderSystem.pushMatrix();
+        RenderSystem.popMatrix();
         //#else
         //$$ GlStateManager.popMatrix();
         //#endif

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/MinecraftPoseStack.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/MinecraftPoseStack.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2024  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.hendrixshen.magiclib.impl.render.matrix;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.math.Matrix4f;
+import lombok.AllArgsConstructor;
+import top.hendrixshen.magiclib.api.render.matrix.MatrixStack;
+
+//#if MC > 11404
+import com.mojang.blaze3d.vertex.PoseStack;
+//#endif
+
+/**
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/e8edce20f53a1062c570af99a740fb6db0e73447/src/main/java/me/fallenbreath/tweakermore/util/render/matrix/McMatrixStack.java">TweakerMore</a>
+ */
+//#if MC > 11502
+@AllArgsConstructor
+//#if MC < 11700
+@SuppressWarnings("deprecation")
+//#endif
+//#endif
+public class MinecraftPoseStack implements MatrixStack {
+    //#if MC > 11502
+    private final PoseStack poseStack;
+    //#endif
+
+    //#if MC > 11404
+    @Override
+    public PoseStack getPoseStack() {
+        //#if MC > 11502
+        return this.poseStack;
+        //#else
+        //$$ throw new RuntimeException("MinecraftPoseStack < mc1.16 does not support getPoseStack()");
+        //#endif
+    }
+    //#endif
+
+    @Override
+    public void pushMatrix() {
+        //#if MC > 11605
+        //$$ this.poseStack.pushPose();
+        //#elseif MC > 11404
+        RenderSystem.pushMatrix();
+        //#else
+        //$$ GlStateManager.pushMatrix();
+        //#endif
+    }
+
+    @Override
+    public void popMatrix() {
+        //#if MC > 11605
+        //$$ this.poseStack.popPose();
+        //#elseif MC > 11404
+        RenderSystem.pushMatrix();
+        //#else
+        //$$ GlStateManager.popMatrix();
+        //#endif
+    }
+
+    @Override
+    public void translate(double x, double y, double z) {
+        //#if MC > 11605
+        //$$ this.poseStack.translate(x, y, z);
+        //#elseif MC > 11404
+        RenderSystem.translated(x, y, z);
+        //#else
+        //$$ GlStateManager.translated(x, y, z);
+        //#endif
+    }
+
+    @Override
+    public void scale(double x, double y, double z) {
+        //#if MC > 11605
+        //$$ this.poseStack.scale((float) x, (float) y, (float) z);
+        //#elseif MC > 11404
+        RenderSystem.scaled(x, y, z);
+        //#else
+        //$$ GlStateManager.scaled(x, y, z);
+        //#endif
+    }
+
+    @Override
+    public void mulMatrix(Matrix4f matrix4f) {
+        //#if MC > 11605
+        //$$ this.poseStack.mulPoseMatrix(matrix4f);
+        //#elseif MC > 11404
+        RenderSystem.multMatrix(matrix4f);
+        //#else
+        //$$ GlStateManager.multMatrix(matrix4f);
+        //#endif
+    }
+}

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/event/render/LevelRendererMixin.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/event/render/LevelRendererMixin.java
@@ -17,6 +17,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import top.hendrixshen.magiclib.impl.event.EventManager;
 import top.hendrixshen.magiclib.impl.event.minecraft.render.RenderLevelEvent;
 
+//#if MC > 12006
+//$$ import net.minecraft.client.DeltaTracker;
+//#endif
+
+//#if MC > 12004
+//$$ import org.joml.Matrix4fStack;
+//$$ import top.hendrixshen.magiclib.libs.com.llamalad7.mixinextras.sugar.Local;
+//#endif
+
 //#if MC > 11903
 //$$ import org.spongepowered.asm.mixin.injection.Slice;
 //#endif
@@ -34,29 +43,37 @@ public class LevelRendererMixin {
             )
     )
     private void preRenderLevel(
+            //#if MC > 12006
+            //$$ DeltaTracker deltaTracker,
+            //#else
             //#if MC < 12005
-            PoseStack poseStack,
+            PoseStack matrixStack,
             //#endif
             float tickDelta,
             long limitTime,
+            //#endif
             boolean renderBlockOutline,
             Camera camera,
             GameRenderer gameRenderer,
             LightTexture lightTexture,
-            Matrix4f matrix4f,
+            Matrix4f frustumMatrix,
             //#if MC > 12004
-            //$$ Matrix4f matrix4f2,
+            //$$ Matrix4f projectionMatrix,
             //#endif
             CallbackInfo ci
     ) {
         EventManager.dispatch(new RenderLevelEvent.PreRender(RenderLevelEvent.LevelRenderContext.of(
                 this.level,
                 //#if MC > 12004
-                //$$ new PoseStack(),
+                //$$ new Matrix4fStack(),
                 //#elseif MC > 11502
-                poseStack,
+                matrixStack,
                 //#endif
+                //#if MC > 12006
+                //$$ deltaTracker.getGameTimeDeltaPartialTick(false)
+                //#else
                 tickDelta
+                //#endif
         )));
     }
 
@@ -87,29 +104,38 @@ public class LevelRendererMixin {
             )
     )
     private void postRenderLevel(
+            //#if MC > 12006
+            //$$ DeltaTracker deltaTracker,
+            //#else
             //#if MC < 12005
-            PoseStack poseStack,
+            PoseStack matrixStack,
             //#endif
             float tickDelta,
             long limitTime,
+            //#endif
             boolean renderBlockOutline,
             Camera camera,
             GameRenderer gameRenderer,
             LightTexture lightTexture,
-            Matrix4f matrix4f,
+            Matrix4f frustumMatrix,
             //#if MC > 12004
-            //$$ Matrix4f matrix4f2,
+            //$$ Matrix4f projectionMatrix,
             //#endif
             CallbackInfo ci
+            //#if MC > 12004
+            //$$ , @Local Matrix4fStack matrixStack
+            //#endif
     ) {
         EventManager.dispatch(new RenderLevelEvent.PostRender(RenderLevelEvent.LevelRenderContext.of(
                 this.level,
-                //#if MC > 12004
-                //$$ new PoseStack(),
-                //#elseif MC > 11502
-                poseStack,
+                //#if MC > 11502
+                matrixStack,
                 //#endif
+                //#if MC > 12006
+                //$$ deltaTracker.getGameTimeDeltaPartialTick(false)
+                //#else
                 tickDelta
+                //#endif
         )));
     }
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/render/RenderContextUtil.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/render/RenderContextUtil.java
@@ -1,0 +1,4 @@
+package top.hendrixshen.magiclib.util.minecraft.render;
+
+public class RenderContextUtil {
+}

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/render/RenderUtil.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/render/RenderUtil.java
@@ -25,14 +25,22 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
 import top.hendrixshen.magiclib.api.compat.minecraft.client.gui.FontCompat;
 
 //#if MC > 11502
 import net.minecraft.util.FormattedCharSequence;
 //#endif
 
+//#if MC > 11404
+//#if MC < 12100
+import com.mojang.blaze3d.vertex.Tesselator;
+//#endif
+import net.minecraft.client.renderer.MultiBufferSource;
+//#endif
+
 /**
- * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/10e1a937aadcefb1f2d9d9bab8badc873d4a5b3d/src/main/java/me/fallenbreath/tweakermore/util/render/RenderUtil.java">TweakerMore<a/>
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/e8edce20f53a1062c570af99a740fb6db0e73447/src/main/java/me/fallenbreath/tweakermore/util/render/RenderUtil.java">TweakerMore<a/>
  */
 @Environment(EnvType.CLIENT)
 public class RenderUtil {
@@ -50,9 +58,28 @@ public class RenderUtil {
         return fontCompat.width(text);
     }
 
+    public static int getSizeScalingXSign() {
+        // Stupid change in 24w21a.
+        //#if MC > 12006
+        //$$ return 1;
+        //#else
+        return -1;
+        //#endif
+    }
+
     //#if MC > 11502
     public static int getRenderWidth(FormattedCharSequence text) {
         return RenderUtil.TEXT_RENDERER.width(text);
+    }
+    //#endif
+
+    //#if MC > 11404
+    public static MultiBufferSource.@NotNull BufferSource getBufferSource() {
+        //#if MC > 12006
+        //$$ return Minecraft.getInstance().renderBuffers().bufferSource();
+        //#else
+        return MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
+        //#endif
     }
     //#endif
 }

--- a/magiclib-minecraft-api/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-minecraft-api/versions/1.14.4-fabric/build.gradle
@@ -158,22 +158,25 @@ loom {
     // Setup client default settings.
     runClient {
         defaultCharacterEncoding("UTF-8")
-        file("${projectDir}/run/client/config").mkdirs()
-        file("${projectDir}/run/client/options.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("autoJump:false")
-                        writer.writeLine("enableVsync:false")
-                        writer.writeLine("forceUnicodeFont:true")
-                        writer.writeLine("fov:1.0")
-                        writer.writeLine("gamma:16.0")
-                        writer.writeLine("guiScale:3")
-                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                        writer.writeLine("maxFps:260")
-                        writer.writeLine("renderDistance:10")
-                        writer.writeLine("soundCategory_master:0.0")
+
+        doFirst {
+            file("${projectDir}/run/client/config").mkdirs()
+            file("${projectDir}/run/client/options.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("autoJump:false")
+                            writer.writeLine("enableVsync:false")
+                            writer.writeLine("forceUnicodeFont:true")
+                            writer.writeLine("fov:1.0")
+                            writer.writeLine("gamma:16.0")
+                            writer.writeLine("guiScale:3")
+                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                            writer.writeLine("maxFps:260")
+                            writer.writeLine("renderDistance:10")
+                            writer.writeLine("soundCategory_master:0.0")
+                        }
                     }
                 }
             }
@@ -184,25 +187,20 @@ loom {
     runServer {
         defaultCharacterEncoding("UTF-8")
 
-        // Agree eula before server init.
-        file("${projectDir}/run/server/eula.txt").with { File f ->
-            {
-                if (!f.exists()) {
-                    f.parentFile.mkdirs()
-                    f.withWriter { BufferedWriter writer ->
-                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                        writer.writeLine("#${new Date()}")
-                        writer.writeLine("eula=true")
+        doFirst {
+            // Agree eula before server init.
+            file("${projectDir}/run/server/eula.txt").with { File f ->
+                {
+                    if (!f.exists()) {
+                        f.parentFile.mkdirs()
+                        f.withWriter { BufferedWriter writer ->
+                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                            writer.writeLine("#${new Date()}")
+                            writer.writeLine("eula=true")
+                        }
                     }
                 }
             }
-        }
-
-        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-            new File("${projectDir}/run/server").mkdirs()
-            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-            bufferedWriter.writeLine("eula=true")
-            bufferedWriter.close()
         }
     }
 }
@@ -398,11 +396,31 @@ tasks.withType(JavaCompile).configureEach { JavaCompile task ->
     }
 }
 
+tasks.register("cleanRuns", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).parentFile.deleteDir()
+    }
+}
+
+tasks.register("cleanRunClient", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.client.runDir).deleteDir()
+    }
+}
+
+tasks.register("cleanRunServer", DefaultTask.class) {
+    doLast {
+        file(loom.runConfigs.server.runDir).deleteDir()
+    }
+}
+
 [
+        "cleanRuns", "cleanRunClient", "cleanRunServer",
         "runClient", "runServer",
         "runMixinAuditClient", "runMixinAuditServer",
         "preprocessCode", "preprocessResources",
-        "preprocessTestCode", "preprocessTestResources"].forEach { taskName ->
+        "preprocessTestCode", "preprocessTestResources"
+].forEach { taskName ->
     if (tasks.getNames().contains(taskName)) {
         tasks.named(taskName) {
             it.group("${project.property("mod.id")}")

--- a/magiclib-minecraft-api/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-minecraft-api/versions/1.14.4-fabric/build.gradle
@@ -61,10 +61,6 @@ repositories {
     maven {
         name("Jitpack Maven")
         url("https://jitpack.io")
-
-        content {
-            includeGroup("com.github.Nyan-Work")
-        }
     }
 
     mavenCentral()
@@ -141,71 +137,72 @@ loom {
         runDir("run/server")
     }
 
-    runs {
-        mixinAuditClient {
-            inherit(client)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/client")
-        }
+    if (fabricLike) {
+        runs {
+            mixinAuditClient {
+                inherit(client)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/client")
+            }
 
-        mixinAuditServer {
-            inherit(server)
-            vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
-            ideConfigGenerated(false)
-            runDir("run/server")
+            mixinAuditServer {
+                inherit(server)
+                vmArgs("-Dmagiclib.debug.mixinAuditor.enable=true")
+                ideConfigGenerated(false)
+                runDir("run/server")
+            }
         }
     }
 
-    if (fabricLike) {
-        // Setup client default settings.
-        runClient {
-            defaultCharacterEncoding("UTF-8")
-            file("${projectDir}/run/client/config").mkdirs()
-            file("${projectDir}/run/client/options.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("autoJump:false")
-                            writer.writeLine("enableVsync:false")
-                            writer.writeLine("forceUnicodeFont:true")
-                            writer.writeLine("fov:1.0")
-                            writer.writeLine("gamma:16.0")
-                            writer.writeLine("guiScale:3")
-                            writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
-                            writer.writeLine("maxFps:260")
-                            writer.writeLine("renderDistance:10")
-                            writer.writeLine("soundCategory_master:0.0")
-                        }
+    // Setup client default settings.
+    runClient {
+        defaultCharacterEncoding("UTF-8")
+        file("${projectDir}/run/client/config").mkdirs()
+        file("${projectDir}/run/client/options.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("autoJump:false")
+                        writer.writeLine("enableVsync:false")
+                        writer.writeLine("forceUnicodeFont:true")
+                        writer.writeLine("fov:1.0")
+                        writer.writeLine("gamma:16.0")
+                        writer.writeLine("guiScale:3")
+                        writer.writeLine("lang:${Locale.getDefault().toString().toLowerCase()}")
+                        writer.writeLine("maxFps:260")
+                        writer.writeLine("renderDistance:10")
+                        writer.writeLine("soundCategory_master:0.0")
+                    }
+                }
+            }
+        }
+    }
+
+    // Setup server default settings.
+    runServer {
+        defaultCharacterEncoding("UTF-8")
+
+        // Agree eula before server init.
+        file("${projectDir}/run/server/eula.txt").with { File f ->
+            {
+                if (!f.exists()) {
+                    f.parentFile.mkdirs()
+                    f.withWriter { BufferedWriter writer ->
+                        writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
+                        writer.writeLine("#${new Date()}")
+                        writer.writeLine("eula=true")
                     }
                 }
             }
         }
 
-        // Setup server default settings.
-        runServer {
-            defaultCharacterEncoding("UTF-8")
-
-            // Agree eula before server init.
-            file("${projectDir}/run/server/eula.txt").with { File f ->
-                {
-                    if (!f.exists()) {
-                        f.parentFile.mkdirs()
-                        f.withWriter { BufferedWriter writer ->
-                            writer.writeLine("#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://account.mojang.com/documents/minecraft_eula).")
-                            writer.writeLine("#${new Date()}")
-                            writer.writeLine("eula=true")
-                        }
-                    }
-                }
-            }
-            if (!new File("${projectDir}/run/server/eula.txt").exists()) {
-                new File("${projectDir}/run/server").mkdirs()
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
-                bufferedWriter.writeLine("eula=true")
-                bufferedWriter.close()
-            }
+        if (!new File("${projectDir}/run/server/eula.txt").exists()) {
+            new File("${projectDir}/run/server").mkdirs()
+            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("${projectDir}/run/server/eula.txt"))
+            bufferedWriter.writeLine("eula=true")
+            bufferedWriter.close()
         }
     }
 }

--- a/magiclib-minecraft-api/versions/1.19.3-fabric/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/JomlMatrixStack.java
+++ b/magiclib-minecraft-api/versions/1.19.3-fabric/src/main/java/top/hendrixshen/magiclib/impl/render/matrix/JomlMatrixStack.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2024  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.hendrixshen.magiclib.impl.render.matrix;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import lombok.AllArgsConstructor;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fStack;
+import top.hendrixshen.magiclib.api.render.matrix.MatrixStack;
+
+/**
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/e8edce20f53a1062c570af99a740fb6db0e73447/versions/1.19.3/src/main/java/me/fallenbreath/tweakermore/util/render/matrix/JomlMatrixStack.java">TweakerMore</a>
+ */
+@AllArgsConstructor
+public class JomlMatrixStack implements MatrixStack {
+    private final Matrix4fStack matrixStack;
+
+    @Override
+    public PoseStack getPoseStack() {
+        throw new RuntimeException("JomlMatrixStack does not support getPoseStack()");
+    }
+
+    @Override
+    public void pushMatrix() {
+        this.matrixStack.pushMatrix();
+    }
+
+    @Override
+    public void popMatrix() {
+        this.matrixStack.popMatrix();
+    }
+
+    @Override
+    public void translate(double x, double y, double z) {
+        this.matrixStack.translate((float)x, (float)y, (float)z);
+    }
+
+    @Override
+    public void scale(double x, double y, double z) {
+        this.matrixStack.scale((float)x, (float)y, (float)z);
+    }
+
+    @Override
+    public void mulMatrix(Matrix4f matrix4f) {
+        this.matrixStack.mul(matrix4f);
+    }
+}

--- a/magiclib-minecraft-api/versions/1.20.1-fabric/src/main/java/top/hendrixshen/magiclib/util/minecraft/render/RenderContextUtil.java
+++ b/magiclib-minecraft-api/versions/1.20.1-fabric/src/main/java/top/hendrixshen/magiclib/util/minecraft/render/RenderContextUtil.java
@@ -1,0 +1,14 @@
+package top.hendrixshen.magiclib.util.minecraft.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import top.hendrixshen.magiclib.mixin.minecraft.accessor.GuiGraphicsAccessor;
+
+public class RenderContextUtil {
+    public static GuiGraphics createDrawContext(PoseStack poseStack) {
+        GuiGraphics drawContext = new GuiGraphics(Minecraft.getInstance(), RenderUtil.getBufferSource());
+        ((GuiGraphicsAccessor) drawContext).magiclib$setPose(poseStack);
+        return drawContext;
+    }
+}

--- a/magiclib-minecraft-api/versions/1.21.0-fabric/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.0-fabric/gradle.properties
@@ -1,0 +1,6 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21- <1.21.1-
+dependencies.minecraft_version=1.21
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-minecraft-api/versions/1.21.0-fabric/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.21.0-fabric/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.0-neoforge/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.neoforge_version=21.0.78-beta
+dependencies.minecraft_dependency=1.21
+dependencies.minecraft_version=1.21
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21

--- a/magiclib-minecraft-api/versions/1.21.0-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.21.0-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/mapping-1.21.0-fabric-neoforge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.21.0-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-wrapper/fabric/build.gradle
+++ b/magiclib-wrapper/fabric/build.gradle
@@ -16,6 +16,7 @@ allprojects {
 Project coreProject = evaluationDependsOn(":magiclib-core:${project.name}")
 
 jar {
+    outputs.upToDateWhen { false }
     dependsOn(coreProject.tasks.shadowJar)
 
     doFirst {
@@ -72,6 +73,7 @@ subprojects {
     }
 
     jar {
+        outputs.upToDateWhen { false }
         dependsOn(submodules.collect { it.tasks.remapJar })
         dependsOn(project.parent.tasks.jar)
 

--- a/settings.json
+++ b/settings.json
@@ -22,7 +22,8 @@
         "1.19.4-forge",
 
         "1.20.2-neoforge",
-        "1.20.6-neoforge"
+        "1.20.6-neoforge",
+        "1.21.0-neoforge"
       ]
     },
     "magiclib-legacy-compat": {
@@ -64,7 +65,8 @@
         "1.18.2-forge",
         "1.19.4-forge",
 
-        "1.20.6-neoforge"
+        "1.20.6-neoforge",
+        "1.21.0-neoforge"
       ]
     },
     "magiclib-minecraft-api": {
@@ -89,7 +91,8 @@
         "1.19.4-forge",
 
         "1.20.2-neoforge",
-        "1.20.6-neoforge"
+        "1.20.6-neoforge",
+        "1.21.0-neoforge"
       ]
     }
   }

--- a/settings.json
+++ b/settings.json
@@ -15,6 +15,7 @@
         "1.20.2-fabric",
         "1.20.4-fabric",
         "1.20.6-fabric",
+        "1.21.0-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",
@@ -38,7 +39,8 @@
         "1.20.1-fabric",
         "1.20.2-fabric",
         "1.20.4-fabric",
-        "1.20.6-fabric"
+        "1.20.6-fabric",
+        "1.21.0-fabric"
       ]
     },
     "magiclib-malilib-extra": {
@@ -56,6 +58,7 @@
         "1.20.2-fabric",
         "1.20.4-fabric",
         "1.20.6-fabric",
+        "1.21.0-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",
@@ -79,6 +82,7 @@
         "1.20.2-fabric",
         "1.20.4-fabric",
         "1.20.6-fabric",
+        "1.21.0-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",


### PR DESCRIPTION
## Features

### For Minecraft 1.21 (Resolve #78)

- [x] Fabric
- [ ] ~~Forge~~ (The architectury loom toolchain doesn't currently do this) [^1]
- [x] NeoForge

## Development

- Add cleanRuns related tasks
- Disable the forge-like runMixinAudit task in order to make `./gradlew runMixinAuditClient` working
- Standardised Dependency Definitions

[^1]: Consider dropping Forge(1.20.6) support？

