### PR TITLE
Update MaFgLib version

### DIFF
--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/game/malilib/MalilibStuffsInitializer.java
@@ -7,13 +7,7 @@ import fi.dy.masa.malilib.hotkeys.IKeybindProvider;
 import top.hendrixshen.magiclib.impl.malilib.SharedConstants;
 
 //#if FORGE_LIKE
-//#if MC > 12006
-//$$ import org.thinkingstudio.mafglib.util.NeoUtils;
-//#elseif MC > 11701 && MC != 11904
-//$$ import org.thinkingstudio.mafglib.util.ForgePlatformUtils;
-//#else
-//$$ import fi.dy.masa.malilib.compat.forge.ForgePlatformCompat;
-//#endif
+//$$ import top.hendrixshen.magiclib.util.minecraft.ForgePlatformUtil;
 //#endif
 
 public class MalilibStuffsInitializer {
@@ -31,25 +25,17 @@ public class MalilibStuffsInitializer {
     }
 
     //#if FORGE_LIKE
-    //$$ private static void setupForgeConfigGui() {
-    //#if MC > 12006
-    //$$     NeoUtils.getInstance().registerModConfigScreen(SharedConstants.getModIdentifier(),
-    //#elseif MC > 11701 && MC != 11904
-    //$$     ForgePlatformUtils.getInstance().registerModConfigScreen(SharedConstants.getModIdentifier(),
-    //#else
-    //$$     ForgePlatformCompat.getInstance()
-    //$$         .getMod(SharedConstants.getModIdentifier())
-    //$$         .registerModConfigScreen(
-    //#endif
-    //$$             screen -> {
-    //$$                 ConfigGui gui = new ConfigGui();
+    //$$     private static void setupForgeConfigGui() {
+    //$$         ForgePlatformUtil.registerModConfigScreen(SharedConstants.getModIdentifier(),
+    //$$                 screen -> {
+    //$$                     ConfigGui gui = new ConfigGui();
     //#if MC > 11903
-    //$$                 gui.setParent(screen);
+    //$$                     gui.setParent(screen);
     //#else
-    //$$                 gui.setParentGui(screen);
+    //$$                     gui.setParentGui(screen);
     //#endif
-    //$$                 return gui;
-    //$$             });
-    //$$ }
+    //$$                     return gui;
+    //$$                 });
+    //$$     }
     //#endif
 }

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -71,6 +71,7 @@ repositories {
     maven {
         name("badasintended Maven")
         url("https://maven2.bai.lol")
+
         content {
             includeGroup("lol.bai")
         }

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -68,6 +68,14 @@ repositories {
         }
     }
 
+    maven {
+        name("badasintended Maven")
+        url("https://maven2.bai.lol")
+        content {
+            includeGroup("lol.bai")
+        }
+    }
+
     mavenCentral()
 }
 
@@ -76,7 +84,7 @@ def apiDependencies = [
         ["maven.modrinth:malilib"         , "malilib"   , fabricLike && mcVersion < 12100, false],
         ["com.github.sakura-ryoko:malilib", "malilib"   , fabricLike && mcVersion > 12006, false],
         ["maven.modrinth:mafglib"         , "malilib"   , forgeLike                      , false],
-        ["maven.modrinth:neonetwork"      , "neonetwork", forgeLike && mcVersion > 12004 , false],
+        ["lol.bai:badpackets"             , "badpackets", forgeLike && mcVersion > 12004 , false],
 ]
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.

--- a/magiclib-malilib-extra/versions/1.18.2-forge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.18.2-forge/gradle.properties
@@ -3,9 +3,9 @@ dependencies.forge_version=40.2.21
 dependencies.minecraft_dependency=1.18.x
 dependencies.minecraft_version=1.18.2
 
-# Malilib 0.1.12
-# MaFgLib-0.1.12-mc1.18.2.jar
-dependencies.api.malilib_version=0.1.12-mc1.18.2
+# Malilib 0.1.14
+# MaFgLib-0.1.14-mc1.18.2.jar
+dependencies.api.malilib_version=0.1.14-mc1.18.2
 
 # Loom Properties
 loom.platform=forge

--- a/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
@@ -3,9 +3,9 @@ dependencies.neoforge_version=20.6.100-beta
 dependencies.minecraft_dependency=1.20.6
 dependencies.minecraft_version=1.20.6
 
-# Malilib 0.1.7
-# MaFgLib-0.1.7-mc1.20.6.jar
-dependencies.api.malilib_version=0.1.7-mc1.20.6
+# Malilib 0.1.13
+# MaFgLib-0.1.13-mc1.20.6.jar
+dependencies.api.malilib_version=0.1.13-mc1.20.6
 
 # BadPackets neo-0.7.3
 # badpackets-neo-0.7.3.jar

--- a/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
@@ -7,9 +7,9 @@ dependencies.minecraft_version=1.20.6
 # MaFgLib-0.1.7-mc1.20.6.jar
 dependencies.api.malilib_version=0.1.7-mc1.20.6
 
-# NeoNetwork 0.1.5
-# NeoNetwork-0.1.5+mc1.20.6.jar
-dependencies.api.neonetwork_version=0.1.5+mc1.20.6
+# BadPackets neo-0.7.3
+# badpackets-neo-0.7.3.jar
+dependencies.api.badpackets_version=neo-0.7.3
 
 # Loom Properties
 loom.platform=neoforge

--- a/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.6-neoforge/gradle.properties
@@ -3,9 +3,9 @@ dependencies.neoforge_version=20.6.100-beta
 dependencies.minecraft_dependency=1.20.6
 dependencies.minecraft_version=1.20.6
 
-# Malilib 0.1.13
-# MaFgLib-0.1.13-mc1.20.6.jar
-dependencies.api.malilib_version=0.1.13-mc1.20.6
+# Malilib 0.1.15
+# MaFgLib-0.1.15-mc1.20.6.jar
+dependencies.api.malilib_version=0.1.15-mc1.20.6
 
 # BadPackets neo-0.7.3
 # badpackets-neo-0.7.3.jar

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
@@ -3,9 +3,9 @@ dependencies.neoforge_version=21.0.78-beta
 dependencies.minecraft_dependency=1.21
 dependencies.minecraft_version=1.21
 
-# Malilib 0.1.16
-# MaFgLib-0.1.16-mc1.21.jar
-dependencies.api.malilib_version=0.1.16-mc1.21
+# Malilib 0.1.19
+# MaFgLib-0.1.19-mc1.21.jar
+dependencies.api.malilib_version=0.1.19-mc1.21
 
 # BadPackets neo-0.8.1
 # badpackets-neo-0.8.1.jar

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
@@ -7,9 +7,9 @@ dependencies.minecraft_version=1.21
 # MaFgLib-0.1.14-mc1.21.jar
 dependencies.api.malilib_version=0.1.14-mc1.21
 
-# NeoNetwork 0.1.5
-# NeoNetwork-0.1.5+mc1.21.jar
-dependencies.api.neonetwork_version=0.1.5+mc1.21
+# BadPackets neo-0.8.1
+# badpackets-neo-0.8.1.jar
+dependencies.api.badpackets_version=neo-0.8.1
 
 # Loom Properties
 loom.platform=neoforge

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
@@ -3,8 +3,8 @@ dependencies.neoforge_version=21.0.78-beta
 dependencies.minecraft_dependency=1.21
 dependencies.minecraft_version=1.21
 
-# Malilib 0.1.14
-# MaFgLib-0.1.14-mc1.21.jar
+# Malilib 0.1.16
+# MaFgLib-0.1.16-mc1.21.jar
 dependencies.api.malilib_version=0.1.16-mc1.21
 
 # BadPackets neo-0.8.1

--- a/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.0-neoforge/gradle.properties
@@ -5,7 +5,7 @@ dependencies.minecraft_version=1.21
 
 # Malilib 0.1.14
 # MaFgLib-0.1.14-mc1.21.jar
-dependencies.api.malilib_version=0.1.14-mc1.21
+dependencies.api.malilib_version=0.1.16-mc1.21
 
 # BadPackets neo-0.8.1
 # badpackets-neo-0.8.1.jar

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/ForgePlatformUtil.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/ForgePlatformUtil.java
@@ -1,0 +1,57 @@
+//#if FORGE_LIKE
+//$$ package top.hendrixshen.magiclib.util.minecraft;
+//$$
+//$$ import net.minecraft.client.gui.screens.Screen;
+//$$
+//$$ import java.util.function.Function;
+//$$
+//#if NEO_FORGE
+//$$ import net.neoforged.fml.ModList;
+//$$
+//#if MC > 12002
+//$$ import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+//#else
+//$$ import net.neoforged.neoforge.client.ConfigScreenHandler;
+//#endif
+//#else
+//$$ import net.minecraftforge.fml.ModList;
+//$$
+//#if MC > 11802
+//$$ import net.minecraftforge.client.ConfigScreenHandler;
+//#elseif MC > 11701
+//$$ import net.minecraftforge.client.ConfigGuiHandler;
+//#else
+//$$ import net.minecraftforge.fmlclient.ConfigGuiHandler;
+//#endif
+//#endif
+//$$
+//$$ public class ForgePlatformUtil {
+//$$     private ForgePlatformUtil() {
+//$$         throw new AssertionError("No top.hendrixshen.magiclib.util.minecraft.ForgePlatformUtil instances for you!");
+//$$     }
+//$$
+//$$     public static void registerModConfigScreen(String modId, Function<Screen, Screen> screenFactory) {
+//$$         ModList.get().getModContainerById(modId)
+//$$                 .orElseThrow(RuntimeException::new)
+//$$                 .registerExtensionPoint(
+//#if NEO_FORGE
+//#if MC > 12002
+//$$                         IConfigScreenFactory.class,
+//$$                         (client, screen) -> screenFactory.apply(screen)
+//#else
+//$$                         ConfigScreenHandler.ConfigScreenFactory.class,
+//$$                         () -> new ConfigScreenHandler.ConfigScreenFactory((client, screen) -> screenFactory.apply(screen))
+//#endif
+//#else
+//#if MC > 11802
+//$$                         ConfigScreenHandler.ConfigScreenFactory.class,
+//$$                         () -> new ConfigScreenHandler.ConfigScreenFactory((client, screen) -> screenFactory.apply(screen))
+//#else
+//$$                         ConfigGuiHandler.ConfigGuiFactory.class,
+//$$                         () -> new ConfigGuiHandler.ConfigGuiFactory((client, screen) -> screenFactory.apply(screen))
+//#endif
+//#endif
+//$$         );
+//$$     }
+//$$ }
+//#endif


### PR DESCRIPTION
MaFgLib 0.1.13-mc1.20.6 and 0.1.16-mc1.21 will use badpackets as the packet lib after that.