### PR TITLE
Add platform type to dependency check & platform api update

### DIFF
--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/DependencyType.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/DependencyType.java
@@ -13,10 +13,15 @@ public enum DependencyType {
      */
     MOD_ID,
     /**
+     * Test if the platform satisfies the condition.
+     * (see {@link top.hendrixshen.magiclib.api.platform.PlatformType PlatformType}).
+     */
+    PLATFORM,
+    /**
      * Test if the predicate satisfies the condition.
      * (see {@link top.hendrixshen.magiclib.util.collect.SimplePredicate SimplePredicate}).
      */
-    PREDICATE,
+    PREDICATE
     ;
 
     public boolean matches(DependencyType type) {

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/annotation/Dependency.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/dependency/annotation/Dependency.java
@@ -2,6 +2,7 @@ package top.hendrixshen.magiclib.api.dependency.annotation;
 
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
 import top.hendrixshen.magiclib.api.platform.DistType;
+import top.hendrixshen.magiclib.api.platform.PlatformType;
 import top.hendrixshen.magiclib.util.collect.SimplePredicate;
 
 import java.lang.annotation.Retention;
@@ -39,8 +40,17 @@ public @interface Dependency {
     DependencyType dependencyType() default DependencyType.MOD_ID;
 
     /**
+     * Platform type.
+     * <br/>The value is used if {@link Dependency#dependencyType()} == {@link DependencyType#PLATFORM}
+     * <p>Only if the specified platform satisfied condition.
+     */
+    PlatformType platformType() default PlatformType.ANY;
+
+    /**
      * Dist type.
-     * <p>Only if the specified dist satisfied condition.
+     * <br/>The value is used if {@link Dependency#dependencyType()} == {@link DependencyType#DIST}
+     * <p>
+     * Only if the specified dist satisfied condition.
      */
     DistType distType() default DistType.ANY;
 

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/platform/PlatformType.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/platform/PlatformType.java
@@ -1,31 +1,65 @@
 package top.hendrixshen.magiclib.api.platform;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.jetbrains.annotations.ApiStatus;
 
 @Getter
+@AllArgsConstructor
 public enum PlatformType {
+    ANY("any"),
     FABRIC("fabric"),
     FABRIC_LIKE("fabric_like"),
     FORGE("forge"),
-    NEOFORGE("neoforge"),
     FORGE_LIKE("forge_like"),
-    QUILT("quilt");
+    NEOFORGE("neoforge"),
+    QUILT("quilt"),
+    UNKNOWN("unknown")
+    ;
 
     private final String name;
 
-    PlatformType(String name) {
-        this.name = name;
-    }
-
+    // This method should be static.
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval
     public boolean isForgeLike(PlatformType type) {
-        return this == PlatformType.FORGE_LIKE || type == PlatformType.FORGE_LIKE || type == this;
+        return type == PlatformType.FORGE_LIKE || type == PlatformType.FORGE || type == PlatformType.NEOFORGE;
     }
 
+    // This method should be static.
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval
     public boolean isFabricLike(PlatformType type) {
-        return this == PlatformType.FABRIC_LIKE || type == PlatformType.FABRIC_LIKE || type == this;
+        return type == PlatformType.FABRIC_LIKE || type == PlatformType.FABRIC || type == PlatformType.QUILT;
+    }
+
+    public boolean isForgeLike() {
+        return this.isForgeLike(this);
+    }
+
+    public boolean isFabricLike() {
+        return this.isFabricLike(this);
     }
 
     public boolean matches(PlatformType type) {
-        return type == this || this.isFabricLike(type) || this.isForgeLike(type);
+        if (this == PlatformType.UNKNOWN || type == PlatformType.UNKNOWN) {
+            return false;
+        }
+
+        if (this == PlatformType.ANY || type == PlatformType.ANY) {
+            return true;
+        }
+
+        if (type == PlatformType.FABRIC_LIKE && this.isFabricLike() ||
+                this == PlatformType.FABRIC_LIKE && type.isFabricLike()) {
+            return true;
+        }
+
+        if (type == PlatformType.FORGE_LIKE && this.isForgeLike() ||
+                this == PlatformType.FORGE_LIKE && type.isForgeLike()) {
+            return true;
+        }
+
+        return type == this;
     }
 }

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/CommonUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/CommonUtil.java
@@ -1,0 +1,17 @@
+package top.hendrixshen.magiclib.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class CommonUtil {
+    public static <T> T make(@NotNull Supplier<T> factory) {
+        return factory.get();
+    }
+
+    public static <T> T make(T object, @NotNull Consumer<T> initializer) {
+        initializer.accept(object);
+        return object;
+    }
+}

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/ReflectionUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/ReflectionUtil.java
@@ -30,8 +30,8 @@ public class ReflectionUtil {
     }
 
     public static <T> @NotNull ValueContainer<T> newInstance(String className, Class<?>[] type, Object... args) {
-        ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
-        return ReflectionUtil.newInstance(clazz, type, args);
+        ValueContainer<Class<?>> classContainer = ReflectionUtil.getClass(className);
+        return ReflectionUtil.newInstance(classContainer, type, args);
     }
 
     public static <T> @NotNull ValueContainer<T> newInstance(@NotNull ValueContainer<Class<?>> classContainer,
@@ -40,7 +40,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.newInstance(classContainer.get(), type, args);
+        return classContainer.flatMap(clazz -> ReflectionUtil.newInstance(clazz, type, args));
     }
 
     public static <T> @NotNull ValueContainer<T> newInstance(@NotNull Class<?> clazz, Class<?>[] type, Object... args) {
@@ -83,8 +83,8 @@ public class ReflectionUtil {
 
     public static @NotNull ValueContainer<Boolean> setStaticFieldValue(String className, String fieldName,
                                                                        Object value) {
-        ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
-        return ReflectionUtil.setDeclaredFieldValue(clazz, fieldName, null, value);
+        ValueContainer<Class<?>> classContainer = ReflectionUtil.getClass(className);
+        return ReflectionUtil.setDeclaredFieldValue(classContainer, fieldName, null, value);
     }
 
     public static ValueContainer<Boolean> setStaticFieldValue(@NotNull ValueContainer<Class<?>> classContainer,
@@ -93,7 +93,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.setDeclaredFieldValue(classContainer.get(), fieldName, null, value);
+        return classContainer.flatMap(clazz -> ReflectionUtil.setDeclaredFieldValue(clazz, fieldName, null, value));
     }
 
     public static ValueContainer<Boolean> setStaticFieldValue(@NotNull Class<?> clazz, String fieldName, Object value) {
@@ -101,8 +101,8 @@ public class ReflectionUtil {
     }
 
     public static ValueContainer<Field> getDeclaredField(String className, String fieldName) {
-        ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
-        return ReflectionUtil.getDeclaredField(clazz, fieldName);
+        ValueContainer<Class<?>> classContainer = ReflectionUtil.getClass(className);
+        return ReflectionUtil.getDeclaredField(classContainer, fieldName);
     }
 
     public static ValueContainer<Field> getDeclaredField(@NotNull ValueContainer<Class<?>> classContainer,
@@ -111,7 +111,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.getDeclaredField(classContainer.get(), fieldName);
+        return classContainer.flatMap(clazz -> ReflectionUtil.getDeclaredField(clazz, fieldName));
     }
 
     public static @NotNull ValueContainer<Field> getDeclaredField(@NotNull Class<?> clazz, String fieldName) {
@@ -123,8 +123,8 @@ public class ReflectionUtil {
     }
 
     public static <T> ValueContainer<T> getDeclaredFieldValue(String className, String fieldName, Object instance) {
-        ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
-        return ReflectionUtil.getDeclaredFieldValue(clazz, fieldName, instance);
+        ValueContainer<Class<?>> classContainer = ReflectionUtil.getClass(className);
+        return ReflectionUtil.getDeclaredFieldValue(classContainer, fieldName, instance);
     }
 
     public static <T> ValueContainer<T> getDeclaredFieldValue(@NotNull ValueContainer<Class<?>> classContainer,
@@ -133,7 +133,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.getDeclaredFieldValue(classContainer.get(), fieldName, instance);
+        return classContainer.flatMap(clazz -> ReflectionUtil.getDeclaredFieldValue(clazz, fieldName, instance));
     }
 
     public static <T> ValueContainer<T> getDeclaredFieldValue(@NotNull Class<?> clazz, String fieldName,
@@ -151,8 +151,8 @@ public class ReflectionUtil {
 
     public static @NotNull ValueContainer<Boolean> setDeclaredFieldValue(String className, String fieldName,
                                                                          Object instance, Object value) {
-        ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
-        return ReflectionUtil.setDeclaredFieldValue(clazz, fieldName, instance, value);
+        ValueContainer<Class<?>> classContainer = ReflectionUtil.getClass(className);
+        return ReflectionUtil.setDeclaredFieldValue(classContainer, fieldName, instance, value);
     }
 
     public static @NotNull ValueContainer<Boolean> setDeclaredFieldValue(
@@ -161,7 +161,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.setDeclaredFieldValue(classContainer.get(), fieldName, instance, value);
+        return classContainer.flatMap(clazz -> ReflectionUtil.setDeclaredFieldValue(clazz, fieldName, instance, value));
     }
 
     public static ValueContainer<Boolean> setDeclaredFieldValue(@NotNull Class<?> clazz, String fieldName,
@@ -199,8 +199,8 @@ public class ReflectionUtil {
     }
 
     public static <T> ValueContainer<T> getFieldValue(String className, String fieldName, Object instance) {
-        ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
-        return ReflectionUtil.getFieldValue(clazz, fieldName, instance);
+        ValueContainer<Class<?>> classContainer = ReflectionUtil.getClass(className);
+        return ReflectionUtil.getFieldValue(classContainer, fieldName, instance);
     }
 
     public static <T> ValueContainer<T> getFieldValue(@NotNull ValueContainer<Class<?>> classContainer,
@@ -209,7 +209,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.getFieldValue(classContainer.get(), fieldName, instance);
+        return classContainer.flatMap(clazz -> ReflectionUtil.getFieldValue(clazz, fieldName, instance));
     }
 
     public static <T> ValueContainer<T> getFieldValue(@NotNull Class<?> clazz, String fieldName, Object instance) {
@@ -236,7 +236,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.setFieldValue(classContainer.get(), fieldName, instance, value);
+        return classContainer.flatMap(clazz -> ReflectionUtil.setFieldValue(clazz, fieldName, instance, value));
     }
 
     public static ValueContainer<Boolean> setFieldValue(@NotNull Class<?> clazz, String fieldName,
@@ -271,6 +271,18 @@ public class ReflectionUtil {
         return ReflectionUtil.invokeDeclared(clazz, methodName, null, type, args);
     }
 
+    public static <T> ValueContainer<T> invokeStatic(ValueContainer<Method> methodContainer, Object... args) {
+        if (methodContainer.isException()) {
+            return ValueContainer.exception(methodContainer.getException());
+        }
+
+        return methodContainer.flatMap(method -> ReflectionUtil.invokeStatic(method, args));
+    }
+
+    public static <T> ValueContainer<T> invokeStatic(Method method, Object... args) {
+        return ReflectionUtil.invoke(method, null, args);
+    }
+
     public static ValueContainer<Method> getDeclaredMethod(String className, String methodName, Class<?>... type) {
         ValueContainer<Class<?>> clazz = ReflectionUtil.getClass(className);
         return ReflectionUtil.getDeclaredMethod(clazz, methodName, type);
@@ -282,7 +294,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.getDeclaredMethod(classContainer.get(), methodName, type);
+        return classContainer.flatMap(clazz -> ReflectionUtil.getDeclaredMethod(clazz, methodName, type));
     }
 
     public static ValueContainer<Method> getDeclaredMethod(@NotNull Class<?> clazz, String methodName,
@@ -309,20 +321,13 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.invokeDeclared(classContainer.get(), methodName, instance, type, args);
+        return classContainer.flatMap(clazz -> ReflectionUtil.invokeDeclared(clazz, methodName, instance, type, args));
     }
 
     public static <T> ValueContainer<T> invokeDeclared(@NotNull Class<?> clazz, String methodName, Object instance,
                                                        Class<?>[] type, Object... args) {
-        try {
-            Method declaredMethod = clazz.getDeclaredMethod(methodName, type);
-            declaredMethod.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            ValueContainer<T> container = ValueContainer.of((T) declaredMethod.invoke(instance, args));
-            return container;
-        } catch (Exception e) {
-            return ValueContainer.exception(e);
-        }
+        ValueContainer<Method> methodContainer = ReflectionUtil.getDeclaredMethod(clazz, methodName, type);
+        return ReflectionUtil.invoke(methodContainer, instance, args);
     }
 
     public static ValueContainer<Method> getMethod(String className, String methodName, Class<?>... type) {
@@ -336,7 +341,7 @@ public class ReflectionUtil {
             return ValueContainer.exception(classContainer.getException());
         }
 
-        return ReflectionUtil.getMethod(classContainer.get(), methodName, type);
+        return classContainer.flatMap(clazz -> ReflectionUtil.getMethod(clazz, methodName, type));
     }
 
     public static ValueContainer<Method> getMethod(@NotNull Class<?> clazz, String methodName, Class<?>... type) {
@@ -366,8 +371,20 @@ public class ReflectionUtil {
 
     public static <T> ValueContainer<T> invoke(@NotNull Class<?> clazz, String methodName, Object instance,
                                                Class<?>[] type, Object... args) {
+        ValueContainer<Method> methodContainer = ReflectionUtil.getMethod(clazz, methodName, type);
+        return ReflectionUtil.invoke(methodContainer, instance, args);
+    }
+
+    public static <T> ValueContainer<T> invoke(ValueContainer<Method> methodContainer, Object instance, Object... args) {
+        if (methodContainer.isException()) {
+            return ValueContainer.exception(methodContainer.getException());
+        }
+
+        return methodContainer.flatMap(method -> ReflectionUtil.invoke(method, instance, args));
+    }
+
+    public static <T> ValueContainer<T> invoke(Method method, Object instance, Object... args) {
         try {
-            Method method = clazz.getMethod(methodName, type);
             method.setAccessible(true);
             @SuppressWarnings("unchecked")
             ValueContainer<T> container = ValueContainer.of((T) method.invoke(instance, args));

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/VersionUtil.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/util/VersionUtil.java
@@ -20,7 +20,7 @@ public class VersionUtil {
                 .allMatch((versionPredicate) -> VersionUtil.isVersionSatisfyPredicate(version, versionPredicate));
     }
 
-    private static boolean isVersionSatisfyPredicate(String version, String versionPredicate) {
+    public static boolean isVersionSatisfyPredicate(String version, String versionPredicate) {
         SemanticVersion semver;
 
         try {

--- a/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/en_us.yml
+++ b/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/en_us.yml
@@ -45,6 +45,13 @@ magiclib:
             not_found: Mod %1$s not found. Requires %2$s!
             unsatisfied: Mod %1$s (%2$s) detected. Requires %3$s, but found %4$s!
           success: Mod %1$s (%2$s) installed!
+      platform:
+        conflict:
+          fail: "Running on unexpected platform: %1$s."
+          success: "Not running on unexpected platform: %1$s."
+        require:
+          fail: Running on unexpected platform, expected %1$s, but found %2$s.
+          success: "Running on expected platform: %1$s."
       predicate:
         message: Predicate %s test result = %s
   misc:

--- a/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/zh_cn.yml
+++ b/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/zh_cn.yml
@@ -45,6 +45,13 @@ magiclib:
             not_found: 找不到模组 %1$s. 需要 %2$s!
             unsatisfied: "检测到模组 %1$s (%2$s) 需要: %3$s, 实际: %4$s!"
           success: 模组 %1$s (%2$s) 已安装!
+      platform:
+        conflict:
+          fail: "运行在非预期平台: %1$s."
+          success: "未运行在非预期平台: %1$s."
+        require:
+          fail: "运行在非预期平台, 预期: %1$s, 实际: %2$s."
+          success: "运行在预期平台: %1$s."
       predicate:
         message: 谓词 %s 测试结果 = %s
   misc:

--- a/magiclib-core/forge/build.gradle
+++ b/magiclib-core/forge/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly("net.minecraftforge:forge:${project.property("dependencies.forge_version")}:universal")
     compileOnly("net.minecraftforge:forge:${project.property("dependencies.forge_version")}:launcher")
     compileOnly("net.minecraftforge:forgespi:${project.property("dependencies.forgespi_version")}")
+    compileOnly("cpw.mods:modlauncher:${project.property("dependencies.modlauncher_version")}")
     compileOnly("org.apache.maven:maven-artifact:${project.property("dependencies.maven-artifact_version")}")
 }
 

--- a/magiclib-core/forge/gradle.properties
+++ b/magiclib-core/forge/gradle.properties
@@ -1,4 +1,5 @@
 # Dependency Versions
 dependencies.forge_version=1.16.5-36.2.39
 dependencies.forgespi_version=3.2.0
+dependencies.modlauncher_version=8.1.3
 dependencies.maven-artifact_version=3.9.6

--- a/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/api/platform/adapter/forge/ModListAdapter.java
+++ b/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/api/platform/adapter/forge/ModListAdapter.java
@@ -1,15 +1,15 @@
 package top.hendrixshen.magiclib.api.platform.adapter.forge;
 
-import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
-import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
+import net.minecraftforge.forgespi.language.IModFileInfo;
+import net.minecraftforge.forgespi.language.IModInfo;
 import top.hendrixshen.magiclib.util.collect.ValueContainer;
 
 import java.util.Collection;
 
 public interface ModListAdapter {
-    ValueContainer<Collection<ModFileInfo>> getModFiles();
+    ValueContainer<Collection<IModFileInfo>> getModFiles();
 
-    ValueContainer<Collection<ModInfo>> getMods();
+    ValueContainer<Collection<IModInfo>> getMods();
 
-    ValueContainer<ModFileInfo> getModFileById(String identifier);
+    ValueContainer<IModFileInfo> getModFileById(String identifier);
 }

--- a/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/ForgePlatformImpl.java
+++ b/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/ForgePlatformImpl.java
@@ -180,6 +180,11 @@ public final class ForgePlatformImpl implements Platform {
         }
 
         String mcVer = MagicLib.getInstance().getCurrentPlatform().getModVersion("minecraft");
+
+        if (VersionUtil.isVersionSatisfyPredicate(mcVer, ">1.20.5-")) {
+            return this.isDevelopmentEnvironment() ? "mojang" : null;
+        }
+
         String intermediaryMethodName;
 
         if (VersionUtil.isVersionSatisfyPredicate(mcVer, ">1.17-")) {

--- a/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/ForgePlatformImpl.java
+++ b/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/ForgePlatformImpl.java
@@ -2,11 +2,13 @@ package top.hendrixshen.magiclib.impl.platform;
 
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.Maps;
+import cpw.mods.modlauncher.api.INameMappingService;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
@@ -151,11 +153,28 @@ public final class ForgePlatformImpl implements Platform {
             return name;
         }
 
-        if (!this.isDevelopmentEnvironment()) {
-            return null;
-        }
+        String className = ObfuscationReflectionHelper.remapName(INameMappingService.Domain.CLASS,
+                "net.minecraft.src.C_3391_");
 
-        return "mojang";
+        switch (className) {
+            case "net.minecraft.client.Minecraft":
+                String methodName = ObfuscationReflectionHelper.remapName(INameMappingService.Domain.METHOD,
+                        "func_230150_b_");
+
+                if ("updateTitle".equals(methodName)) {
+                    return "mojang";
+                } else if ("setDefaultMinecraftTitle".equals(methodName)) {
+                    return "mcp";
+                }
+
+                return "unknown";
+            case "net.minecraft.client.MinecraftClient":
+                return "yarn";
+            case "net.minecraft.src.C_3391_":
+                return null;
+            default:
+                return "unknown";
+        }
     }
 
     public Dist getCurrentEnvType() {

--- a/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/ForgePlatformImpl.java
+++ b/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/ForgePlatformImpl.java
@@ -10,7 +10,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.FMLPaths;
-import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.jetbrains.annotations.Nullable;
 import top.hendrixshen.magiclib.MagicLib;
@@ -168,7 +167,7 @@ public final class ForgePlatformImpl implements Platform {
                 .or(() -> ForgeLoadingModList.getInstance().getMods())
                 .orElseThrow(() -> new IllegalStateException("Access ModList too early!"))
                 .stream()
-                .map(ModInfo::getModId)
+                .map(IModInfo::getModId)
                 .collect(Collectors.toList());
     }
 

--- a/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/adapter/ForgeLoadingModList.java
+++ b/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/adapter/ForgeLoadingModList.java
@@ -4,12 +4,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.fml.loading.LoadingModList;
-import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
-import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
+import net.minecraftforge.forgespi.language.IModFileInfo;
+import net.minecraftforge.forgespi.language.IModInfo;
 import top.hendrixshen.magiclib.api.platform.adapter.forge.ModListAdapter;
 import top.hendrixshen.magiclib.util.collect.ValueContainer;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ForgeLoadingModList implements ModListAdapter {
@@ -17,17 +18,25 @@ public class ForgeLoadingModList implements ModListAdapter {
     private static final ModListAdapter instance = new ForgeLoadingModList();
 
     @Override
-    public ValueContainer<Collection<ModFileInfo>> getModFiles() {
-        return ValueContainer.ofNullable(LoadingModList.get()).map(LoadingModList::getModFiles);
+    public ValueContainer<Collection<IModFileInfo>> getModFiles() {
+        return ValueContainer.ofNullable(LoadingModList.get())
+                .map(loadingModList -> loadingModList.getModFiles()
+                        .stream()
+                        .map(IModFileInfo.class::cast)
+                        .collect(Collectors.toList()));
     }
 
     @Override
-    public ValueContainer<Collection<ModInfo>> getMods() {
-        return ValueContainer.ofNullable(LoadingModList.get()).map(LoadingModList::getMods);
+    public ValueContainer<Collection<IModInfo>> getMods() {
+        return ValueContainer.ofNullable(LoadingModList.get())
+                .map(loadingModList -> loadingModList.getMods()
+                        .stream()
+                        .map(IModInfo.class::cast)
+                        .collect(Collectors.toList()));
     }
 
     @Override
-    public ValueContainer<ModFileInfo> getModFileById(String identifier) {
+    public ValueContainer<IModFileInfo> getModFileById(String identifier) {
         return ValueContainer.ofNullable(LoadingModList.get())
                 .map(loadingModList -> loadingModList.getModFileById(identifier));
     }

--- a/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/adapter/ForgeModList.java
+++ b/magiclib-core/forge/src/main/java/top/hendrixshen/magiclib/impl/platform/adapter/ForgeModList.java
@@ -1,33 +1,93 @@
 package top.hendrixshen.magiclib.impl.platform.adapter;
 
+import com.google.common.collect.Lists;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
-import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
+import net.minecraftforge.forgespi.language.IModFileInfo;
+import net.minecraftforge.forgespi.language.IModInfo;
 import top.hendrixshen.magiclib.api.platform.adapter.forge.ModListAdapter;
+import top.hendrixshen.magiclib.util.CommonUtil;
+import top.hendrixshen.magiclib.util.ReflectionUtil;
 import top.hendrixshen.magiclib.util.collect.ValueContainer;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ForgeModList implements ModListAdapter {
     @Getter(lazy = true)
     private static final ModListAdapter instance = new ForgeModList();
+    private static final ValueContainer<Method> getModFilesMethod = CommonUtil.make(() -> {
+        ValueContainer<Class<?>> modListClazz = ReflectionUtil.getClass("net.minecraftforge.fml.ModList");
+
+        if (modListClazz.isException()) {
+            return ValueContainer.exception(new RuntimeException("Unable to initialize ModList.", modListClazz.getException()));
+        }
+
+        return ReflectionUtil.getMethod(modListClazz, "getModFiles");
+    });
+    private static final Function<ModList, List<IModFileInfo>> getModFilesFunction = (modList) -> {
+        if (ForgeModList.getModFilesMethod.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        ValueContainer<List<IModFileInfo>> ret = ReflectionUtil.invoke(ForgeModList.getModFilesMethod, modList);
+        return ret.orElse(Lists.newArrayList());
+    };
+
+    private static final ValueContainer<Method> getModsMethod = CommonUtil.make(() -> {
+        ValueContainer<Class<?>> modListClazz = ReflectionUtil.getClass("net.minecraftforge.fml.ModList");
+
+        if (modListClazz.isException()) {
+            return ValueContainer.exception(new RuntimeException("Unable to initialize ModList.", modListClazz.getException()));
+        }
+
+        return ReflectionUtil.getMethod(modListClazz, "getMods");
+    });
+    private static final Function<ModList, List<IModInfo>> getModsFunction = (modList) -> {
+        if (ForgeModList.getModsMethod.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        ValueContainer<List<IModInfo>> ret = ReflectionUtil.invoke(ForgeModList.getModsMethod, modList);
+        return ret.orElse(Lists.newArrayList());
+    };
+
+    private static final ValueContainer<Method> getModFileByIdMethod = CommonUtil.make(() -> {
+        ValueContainer<Class<?>> modListClazz = ReflectionUtil.getClass("net.minecraftforge.fml.ModList");
+
+        if (modListClazz.isException()) {
+            return ValueContainer.exception(new RuntimeException("Unable to initialize ModList.", modListClazz.getException()));
+        }
+
+        return ReflectionUtil.getMethod(modListClazz, "getModFileById", String.class);
+    });
+    private static final BiFunction<ModList, String, IModFileInfo> getModFileByIdFunction = (modList, identifier) -> {
+        if (ForgeModList.getModFileByIdMethod.isEmpty()) {
+            return null;
+        }
+
+        ValueContainer<IModFileInfo> ret = ReflectionUtil.invoke(ForgeModList.getModFileByIdMethod, modList, identifier);
+        return ret.orElse(null);
+    };
 
     @Override
-    public ValueContainer<Collection<ModFileInfo>> getModFiles() {
-        return ValueContainer.ofNullable(ModList.get()).map(ModList::getModFiles);
+    public ValueContainer<Collection<IModFileInfo>> getModFiles() {
+        return ValueContainer.ofNullable(ModList.get()).map(ForgeModList.getModFilesFunction);
     }
 
     @Override
-    public ValueContainer<Collection<ModInfo>> getMods() {
-        return ValueContainer.ofNullable(ModList.get()).map(ModList::getMods);
+    public ValueContainer<Collection<IModInfo>> getMods() {
+        return ValueContainer.ofNullable(ModList.get()).map(ForgeModList.getModsFunction);
     }
 
     @Override
-    public ValueContainer<ModFileInfo> getModFileById(String identifier) {
-        return ValueContainer.ofNullable(ModList.get()).map(modList -> modList.getModFileById(identifier));
+    public ValueContainer<IModFileInfo> getModFileById(String identifier) {
+        return ValueContainer.ofNullable(ModList.get()).map(modList -> ForgeModList.getModFileByIdFunction.apply(modList, identifier));
     }
 }

--- a/magiclib-core/neoforge/src/main/java/top/hendrixshen/magiclib/impl/platform/NeoForgePlatformImpl.java
+++ b/magiclib-core/neoforge/src/main/java/top/hendrixshen/magiclib/impl/platform/NeoForgePlatformImpl.java
@@ -2,6 +2,7 @@ package top.hendrixshen.magiclib.impl.platform;
 
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.Maps;
+import cpw.mods.modlauncher.api.INameMappingService;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.fml.util.ObfuscationReflectionHelper;
 import net.neoforged.neoforgespi.language.IModInfo;
 import org.jetbrains.annotations.Nullable;
 import top.hendrixshen.magiclib.MagicLibProperties;
@@ -148,11 +150,28 @@ public final class NeoForgePlatformImpl implements Platform {
             return name;
         }
 
-        if (!this.isDevelopmentEnvironment()) {
-            return null;
-        }
+        String className = ObfuscationReflectionHelper.remapName(INameMappingService.Domain.CLASS,
+                "net.minecraft.src.C_3391_");
 
-        return "mojang";
+        switch (className) {
+            case "net.minecraft.client.Minecraft":
+                String methodName = ObfuscationReflectionHelper.remapName(INameMappingService.Domain.METHOD,
+                        "func_230150_b_");
+
+                if ("updateTitle".equals(methodName)) {
+                    return "mojang";
+                } else if ("setDefaultMinecraftTitle".equals(methodName)) {
+                    return "mcp";
+                }
+
+                return "unknown";
+            case "net.minecraft.client.MinecraftClient":
+                return "yarn";
+            case "net.minecraft.src.C_3391_":
+                return null;
+            default:
+                return "unknown";
+        }
     }
 
     public Dist getCurrentEnvType() {

--- a/magiclib-core/neoforge/src/main/java/top/hendrixshen/magiclib/impl/platform/adapter/NeoForgeLoadingModList.java
+++ b/magiclib-core/neoforge/src/main/java/top/hendrixshen/magiclib/impl/platform/adapter/NeoForgeLoadingModList.java
@@ -20,15 +20,19 @@ public class NeoForgeLoadingModList implements ModListAdapter {
     @Override
     public ValueContainer<Collection<IModFileInfo>> getModFiles() {
         return ValueContainer.ofNullable(LoadingModList.get())
-                .map(loadingModList -> loadingModList.getModFiles().stream()
-                        .map(modFileInfo -> (IModFileInfo) modFileInfo).collect(Collectors.toList()));
+                .map(loadingModList -> loadingModList.getModFiles()
+                        .stream()
+                        .map(IModFileInfo.class::cast)
+                        .collect(Collectors.toList()));
     }
 
     @Override
     public ValueContainer<Collection<IModInfo>> getMods() {
         return ValueContainer.ofNullable(LoadingModList.get())
-                .map(loadingModList -> loadingModList.getMods().stream()
-                        .map(modFileInfo -> (IModInfo) modFileInfo).collect(Collectors.toList()));
+                .map(loadingModList -> loadingModList.getMods()
+                        .stream()
+                        .map(IModInfo.class::cast)
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/config/MagicConfigBooleanHotkeyedMixin.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/config/MagicConfigBooleanHotkeyedMixin.java
@@ -9,11 +9,39 @@ import fi.dy.masa.malilib.hotkeys.KeybindSettings;
 import fi.dy.masa.malilib.util.JsonUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import top.hendrixshen.magiclib.MagicLib;
+import top.hendrixshen.magiclib.api.dependency.DependencyType;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
+import top.hendrixshen.magiclib.api.platform.PlatformType;
 import top.hendrixshen.magiclib.impl.malilib.config.option.MagicConfigBooleanHotkeyed;
 
-@Dependencies(require = @Dependency(value = "malilib", versionPredicates = "<0.11.4"))
+@Dependencies(
+        require = {
+                @Dependency(value = "malilib", versionPredicates = "<0.11.4"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FABRIC_LIKE)
+        }
+)
+@Dependencies(
+        require = {
+                @Dependency(value = "minecraft", versionPredicates = ">=1.16- <1.18-"),
+                @Dependency(value = "malilib", versionPredicates = "*"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FORGE_LIKE)
+        }
+)
+@Dependencies(
+        require = {
+                @Dependency(value = "minecraft", versionPredicates = "1.16.x"),
+                @Dependency(value = "mafglib", versionPredicates = "*"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FORGE_LIKE)
+        }
+)
+@Dependencies(
+        require = {
+                @Dependency(value = "minecraft", versionPredicates = "1.18.x"),
+                @Dependency(value = "malilib", versionPredicates = "*"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FORGE_LIKE)
+        }
+)
 @Mixin(value = MagicConfigBooleanHotkeyed.class, remap = false)
 public abstract class MagicConfigBooleanHotkeyedMixin extends ConfigBoolean implements IHotkeyTogglable {
     public MagicConfigBooleanHotkeyedMixin(String name, boolean defaultValue, String comment) {

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/mixin/malilib/dev/GuiTextFieldGenericMixin.java
@@ -12,25 +12,32 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.hendrixshen.magiclib.api.dependency.DependencyType;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
+import top.hendrixshen.magiclib.api.platform.PlatformType;
 import top.hendrixshen.magiclib.impl.mixin.BuiltInPredicates;
 
 @Dependencies(
         require = {
                 @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib", versionPredicates = "<0.18.2"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FABRIC_LIKE),
                 @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
                 @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
         }
 )
 @Dependencies(
         require = {
-                @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib"),
-                @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<1.21"),
+                @Dependency(dependencyType = DependencyType.MOD_ID, value = "malilib", versionPredicates = "*"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FORGE_LIKE),
                 @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
                 @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
-        },
-        conflict = {
-                @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib", versionPredicates = ">0.1.8"),
-                @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = ">1.20.4"),
+        }
+)
+@Dependencies(
+        require = {
+                @Dependency(dependencyType = DependencyType.MOD_ID, value = "minecraft", versionPredicates = "<1.20.5"),
+                @Dependency(dependencyType = DependencyType.MOD_ID, value = "mafglib", versionPredicates = "*"),
+                @Dependency(dependencyType = DependencyType.PLATFORM, platformType = PlatformType.FORGE_LIKE),
+                @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.DevMixinPredicate.class),
+                @Dependency(dependencyType = DependencyType.PREDICATE, predicate = BuiltInPredicates.MojangMappingMixinPredicate.class)
         }
 )
 @Mixin(value = GuiTextFieldGeneric.class, remap = false)


### PR DESCRIPTION
## Features
- Add platform type to dependency check 

## Fixes
- Fix Platform::getNamedMappingName api (forge-like)
- Fix ModListAdapter crash[^1] (forge)

[^1]: But also bring breaking changes because of changes in method signatures