### PR TITLE
Fix MixinChecker accidentally skipping mixin classes where the target not exist

### DIFF
--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/DependencyContainer.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/dependency/DependencyContainer.java
@@ -175,9 +175,14 @@ public class DependencyContainer<T> {
                         I18n.tr("magiclib.dependency.result.platform.require.fail",
                                 this.platformType, currentPlatformType)));
             case PREDICATE:
+                if (this.predicate == null) {
+                    return ValueContainer.of(new DependencyCheckResult(true, I18n.tr(
+                            "magiclib.dependency.result.predicate.target_obj_not_exist")));
+                }
+
                 boolean testResult = this.predicate.test(this.obj);
                 return ValueContainer.of(new DependencyCheckResult(testResult, I18n.tr(
-                        "magiclib.dependency.result.predicate.message",
+                        "magiclib.dependency.result.predicate.test_result",
                         this.predicate.getClass().getName(), testResult)));
         }
 
@@ -232,9 +237,14 @@ public class DependencyContainer<T> {
                 return ValueContainer.of(new DependencyCheckResult(true,
                         I18n.tr("magiclib.dependency.result.platform.conflict.success", this.platformType)));
             case PREDICATE:
+                if (this.predicate == null) {
+                    return ValueContainer.of(new DependencyCheckResult(false, I18n.tr(
+                            "magiclib.dependency.result.predicate.target_obj_not_exist")));
+                }
+
                 boolean testResult = this.predicate.test(this.obj);
                 return ValueContainer.of(new DependencyCheckResult(!testResult,
-                        I18n.tr("magiclib.dependency.result.predicate.message",
+                        I18n.tr("magiclib.dependency.result.predicate.test_result",
                                 this.predicate.getClass().getName(), testResult)));
         }
 

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/mixin/checker/SimpleMixinChecker.java
@@ -44,7 +44,7 @@ public class SimpleMixinChecker implements MixinDependencyChecker {
         ClassNode targetClassNode = MixinUtil.getClassNode(targetClassName);
         ClassNode mixinClassNode = MixinUtil.getClassNode(mixinClassName);
 
-        if (targetClassNode == null || mixinClassNode == null) {
+        if (mixinClassNode == null) {
             return false;
         }
 

--- a/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/en_us.yml
+++ b/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/en_us.yml
@@ -53,7 +53,8 @@ magiclib:
           fail: Running on unexpected platform, expected %1$s, but found %2$s.
           success: "Running on expected platform: %1$s."
       predicate:
-        message: Predicate %s test result = %s
+        test_result: Predicate %1$s test result = %2$s
+        target_obj_not_exist: Predicate %1$s test target does not exist, skipped.
   misc:
     version_type:
       beta: Public Beta

--- a/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/zh_cn.yml
+++ b/magiclib-core/common/src/main/resources/assets/magiclib-core/lang/zh_cn.yml
@@ -53,7 +53,8 @@ magiclib:
           fail: "运行在非预期平台, 预期: %1$s, 实际: %2$s."
           success: "运行在预期平台: %1$s."
       predicate:
-        message: 谓词 %s 测试结果 = %s
+        test_result: 谓词 %1$s 测试结果 = %2$s
+        target_obj_not_exist: 谓词 %1$s 测试目标不存在, 已跳过.
   misc:
     version_type:
       beta: 公共测试版


### PR DESCRIPTION
In this case we should leave it to Mixin to decide