### PR TITLE
Minecraft 1.21.4 support

### DIFF
--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -27,6 +27,7 @@ preprocess {
     Node mc_12006_fabric = createNode("better-dev-1.20.6-fabric", 1_20_06, "mojang")
     Node mc_12101_fabric = createNode("better-dev-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("better-dev-1.21.3-fabric", 1_21_03, "mojang")
+    Node mc_12104_fabric = createNode("better-dev-1.21.4-fabric", 1_21_04, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, file("versions/mapping-fabric-1.15.2-1.16.5.txt"))
@@ -41,6 +42,7 @@ preprocess {
     mc_12004_fabric.link(mc_12006_fabric, null)
     mc_12006_fabric.link(mc_12101_fabric, null)
     mc_12101_fabric.link(mc_12103_fabric, null)
+    mc_12103_fabric.link(mc_12104_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("better-dev-1.17.1-forge", 1_17_01, "mojang")
@@ -58,9 +60,11 @@ preprocess {
     Node mc_12006_neoforge = createNode("better-dev-1.20.6-neoforge", 1_20_06, "mojang")
     Node mc_12101_neoforge = createNode("better-dev-1.21.1-neoforge", 1_21_01, "mojang")
     Node mc_12103_neoforge = createNode("better-dev-1.21.3-neoforge", 1_21_03, "mojang")
+    Node mc_12104_neoforge = createNode("better-dev-1.21.4-neoforge", 1_21_04, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
     mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
     mc_12101_fabric.link(mc_12101_neoforge, file("versions/mapping-1.21.1-fabric-neoforge.txt"))
     mc_12103_fabric.link(mc_12103_neoforge, file("versions/mapping-1.21.3-fabric-neoforge.txt"))
+    mc_12104_fabric.link(mc_12104_neoforge, file("versions/mapping-1.21.4-fabric-neoforge.txt"))
 }

--- a/magiclib-better-dev/versions/1.21.4-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.4-fabric/gradle.properties
@@ -1,0 +1,20 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.4- <1.21.5-
+dependencies.minecraft_version=1.21.4
+
+# Fabric API 0.113.0+1.21.4
+dependencies.api.fabric_version=0.113.0+1.21.4
+# Mod Menu 13.0.0-beta.1
+# modmenu-13.0.0-beta.1.jar
+dependencies.api.modmenu_version=13.0.0-beta.1
+
+# IMBlockerFabric 1.0.24
+# imblockerfabric-1.0.24.jar
+dependencies.runtime.imblocker_version=1.0.24
+# In-Game Account Switcher 9.0.2-alpha.1
+# IAS-Fabric-1.21.4-9.0.2-alpha.1.jar
+dependencies.runtime.inGameAccountSwitcher_version=WBbjirJP
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=

--- a/magiclib-better-dev/versions/1.21.4-fabric/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.21.4-fabric/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/1.21.4-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.4-neoforge/gradle.properties
@@ -1,0 +1,18 @@
+# Dependency Versions
+dependencies.neoforge_version=21.4.46-beta
+dependencies.minecraft_dependency=1.21.4
+dependencies.minecraft_version=1.21.4
+
+# IMBlocker 4.0.9b
+# IMBlocker_4.0.9b+1.21.jar
+dependencies.runtime.imblocker_version=4.0.9b+1.21
+# In-Game Account Switcher
+# TODO
+dependencies.runtime.inGameAccountSwitcher_version=0
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=

--- a/magiclib-better-dev/versions/1.21.4-neoforge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.21.4-neoforge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/mapping-1.21.4-fabric-neoforge.txt
+++ b/magiclib-better-dev/versions/mapping-1.21.4-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-legacy-compat/build.gradle
+++ b/magiclib-legacy-compat/build.gradle
@@ -27,6 +27,7 @@ preprocess {
     Node mc_12006_fabric = createNode("legacy-1.20.6-fabric", 1_20_06, "mojang")
     Node mc_12101_fabric = createNode("legacy-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("legacy-1.21.3-fabric", 1_21_03, "mojang")
+    Node mc_12104_fabric = createNode("legacy-1.21.4-fabric", 1_21_04, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, file("versions/mapping-1.15.2-1.16.5.txt"))
@@ -41,4 +42,5 @@ preprocess {
     mc_12004_fabric.link(mc_12006_fabric, null)
     mc_12006_fabric.link(mc_12101_fabric, null)
     mc_12101_fabric.link(mc_12103_fabric, null)
+    mc_12103_fabric.link(mc_12104_fabric, null)
 }

--- a/magiclib-legacy-compat/versions/1.21.3-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.21.3-fabric/gradle.properties
@@ -10,4 +10,4 @@ dependencies.api.carpet_version=1.21.2-1.4.158+v241022
 publish.game_version=1.21.2,1.21.3
 publish.dependencies_list=\
   carpet@1.21.2-1.4.158+v241022(optional){modrinth:TQTTVgYE}{curseforge:349239}#(ignore:github),\
-  malilib@0.22.0(optional){modrinth:GcWjdA9I}{curseforge:303119}#(ignore:github)
+  malilib@0.22.3(optional){modrinth:GcWjdA9I}{curseforge:303119}#(ignore:github)

--- a/magiclib-legacy-compat/versions/1.21.4-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.21.4-fabric/gradle.properties
@@ -1,0 +1,13 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.4- <1.21.5-
+dependencies.minecraft_version=1.21.4
+
+# Carpet - 1.4.161+v241203
+# fabric-carpet-1.21.4-1.4.161+v241203.jar
+dependencies.api.carpet_version=1.21.4-1.4.161+v241203
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=\
+  carpet@1.21.4-1.4.161+v241203(optional){modrinth:TQTTVgYE}{curseforge:349239}#(ignore:github),\
+  malilib@0.23.0(optional){modrinth:GcWjdA9I}{curseforge:303119}#(ignore:github)

--- a/magiclib-legacy-compat/versions/1.21.4-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
+++ b/magiclib-legacy-compat/versions/1.21.4-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/build.gradle
+++ b/magiclib-malilib-extra/build.gradle
@@ -27,6 +27,7 @@ preprocess {
     Node mc_12006_fabric = createNode("malilib-1.20.6-fabric", 1_20_06, "mojang")
     Node mc_12101_fabric = createNode("malilib-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("malilib-1.21.3-fabric", 1_21_03, "mojang")
+    Node mc_12104_fabric = createNode("malilib-1.21.4-fabric", 1_21_04, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, null)
     mc_11502_fabric.link(mc_11605_fabric, null)
@@ -41,6 +42,7 @@ preprocess {
     mc_12004_fabric.link(mc_12006_fabric, null)
     mc_12006_fabric.link(mc_12101_fabric, null)
     mc_12101_fabric.link(mc_12103_fabric, null)
+    mc_12103_fabric.link(mc_12104_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("malilib-1.17.1-forge", 1_17_01, "mojang")
@@ -54,7 +56,11 @@ preprocess {
     // NeoForge
     Node mc_12006_neoforge = createNode("malilib-1.20.6-neoforge", 1_20_06, "mojang")
     Node mc_12101_neoforge = createNode("malilib-1.21.1-neoforge", 1_21_01, "mojang")
+    Node mc_12103_neoforge = createNode("malilib-1.21.3-neoforge", 1_21_03, "mojang")
+    Node mc_12104_neoforge = createNode("malilib-1.21.4-neoforge", 1_21_04, "mojang")
 
     mc_12006_fabric.link(mc_12006_neoforge, null)
     mc_12101_fabric.link(mc_12101_neoforge, null)
+    mc_12103_fabric.link(mc_12103_neoforge, null)
+    mc_12104_fabric.link(mc_12104_neoforge, null)
 }

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/GuiVec3Edit.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/GuiVec3Edit.java
@@ -136,7 +136,16 @@ public class GuiVec3Edit extends GuiBase {
     }
 
     @Override
-    protected void drawScreenBackground(int mouseX, int mouseY) {
+    protected void drawScreenBackground(
+            //#if MC > 12006
+            //$$ GuiGraphics guiGraphics,
+            //#endif
+            int mouseX,
+            int mouseY
+    ) {
+        //#if MC > 12006
+        //$$ super.drawTexturedBG(guiGraphics, this.dialogLeft, this.dialogTop, this.dialogWidth, this.dialogHeight, true);
+        //#endif
         RenderUtils.drawOutlinedBox(this.dialogLeft, this.dialogTop, this.dialogWidth, this.dialogHeight, 0xFF000000, 0xFF999999);
     }
 

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/GuiVec3iListEdit.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/GuiVec3iListEdit.java
@@ -140,7 +140,16 @@ public class GuiVec3iListEdit extends GuiListBase<Vec3i, WidgetVec3iListEditEntr
     }
 
     @Override
-    protected void drawScreenBackground(int mouseX, int mouseY) {
+    protected void drawScreenBackground(
+            //#if MC > 12006
+            //$$ GuiGraphics guiGraphics,
+            //#endif
+            int mouseX,
+            int mouseY
+    ) {
+        //#if MC > 12006
+        //$$ super.drawTexturedBG(guiGraphics, this.dialogLeft, this.dialogTop, this.dialogWidth, this.dialogHeight, true);
+        //#endif
         RenderUtils.drawOutlinedBox(this.dialogLeft, this.dialogTop, this.dialogWidth, this.dialogHeight, 0xFF000000, 0xFF999999);
     }
 

--- a/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.14.4-fabric/build.gradle
@@ -76,12 +76,14 @@ repositories {
     mavenCentral()
 }
 
+String malilib_fabric_ga = project.getProperties().getOrDefault("dependencies.api.malilib_version.use_sakura_fork", false) ?
+        "com.github.sakura-ryoko:malilib" : "maven.modrinth:malilib"
+
 // Module, Property prefix, Resolve condition, Transitive dependencies.
 def apiDependencies = [
-        ["maven.modrinth:malilib"         , "malilib"   , fabricLike && mcVersion < 12104, false],
-        ["com.github.sakura-ryoko:malilib", "malilib"   , fabricLike && mcVersion > 12103, false],
-        ["maven.modrinth:mafglib"         , "malilib"   , forgeLike                      , false],
-        ["lol.bai:badpackets"             , "badpackets", forgeLike && mcVersion > 12004 , false],
+        [malilib_fabric_ga       , "malilib"   , fabricLike                     , false],
+        ["maven.modrinth:mafglib", "malilib"   , forgeLike                      , false],
+        ["lol.bai:badpackets"    , "badpackets", forgeLike && mcVersion > 12004 , false],
 ]
 
 // Module, Property prefix, Resolve condition, Transitive dependencies.

--- a/magiclib-malilib-extra/versions/1.21.3-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.3-neoforge/gradle.properties
@@ -1,0 +1,20 @@
+# Dependency Versions
+dependencies.neoforge_version=21.3.58
+dependencies.minecraft_dependency=1.21.3
+dependencies.minecraft_version=1.21.3
+
+# Malilib 0.2.1
+# MaFgLib-0.2.1-mc1.21.3.jar
+dependencies.api.malilib_version=0.2.1-mc1.21.3
+
+# BadPackets neo-0.8.1
+# badpackets-neo-0.8.1.jar
+dependencies.api.badpackets_version=neo-0.8.1
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21.3
+publish.dependencies_list=\
+  mafglib@0.2.1-mc1.21.3(optional){modrinth:SKI34J7B}{curseforge:910766}#(ignore:github)

--- a/magiclib-malilib-extra/versions/1.21.3-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.21.3-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/1.21.4-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.4-fabric/gradle.properties
@@ -1,0 +1,12 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.4- <1.21.5-
+dependencies.minecraft_version=1.21.4
+
+# Malilib 0.23.0
+# malilib-fabric-1.21.4-0.23.0.jar
+dependencies.api.malilib_version=0.23.0
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=\
+  malilib@0.23.0(optional){modrinth:GcWjdA9I}{curseforge:303119}#(ignore:github)

--- a/magiclib-malilib-extra/versions/1.21.4-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.21.4-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/1.21.4-neoforge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.4-neoforge/gradle.properties
@@ -1,0 +1,20 @@
+# Dependency Versions
+dependencies.neoforge_version=21.4.46-beta
+dependencies.minecraft_dependency=1.21.4
+dependencies.minecraft_version=1.21.4
+
+# Malilib 0.2.1
+# MaFgLib-0.2.1-mc1.21.3.jar
+dependencies.api.malilib_version=0.2.1-mc1.21.4
+
+# BadPackets neo-0.8.1
+# badpackets-neo-0.8.1.jar
+dependencies.api.badpackets_version=neo-0.8.1
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=\
+  mafglib@0.2.1-mc1.21.4(optional){modrinth:SKI34J7B}{curseforge:910766}#(ignore:github)

--- a/magiclib-malilib-extra/versions/1.21.4-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.21.4-neoforge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -27,6 +27,7 @@ preprocess {
     Node mc_12006_fabric = createNode("mc-api-1.20.6-fabric", 1_20_06, "mojang")
     Node mc_12101_fabric = createNode("mc-api-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("mc-api-1.21.3-fabric", 1_21_03, "mojang")
+    Node mc_12104_fabric = createNode("mc-api-1.21.4-fabric", 1_21_04, "mojang")
 
     mc_11404_fabric.link(mc_11502_fabric, file("versions/mapping-fabric-1.14.4-1.15.2.txt"))
     mc_11502_fabric.link(mc_11605_fabric, file("versions/mapping-fabric-1.15.2-1.16.5.txt"))
@@ -41,6 +42,7 @@ preprocess {
     mc_12004_fabric.link(mc_12006_fabric, null)
     mc_12006_fabric.link(mc_12101_fabric, null)
     mc_12101_fabric.link(mc_12103_fabric, null)
+    mc_12103_fabric.link(mc_12104_fabric, null)
 
     // Forge
     Node mc_11701_forge = createNode("mc-api-1.17.1-forge", 1_17_01, "mojang")
@@ -56,9 +58,11 @@ preprocess {
     Node mc_12006_neoforge = createNode("mc-api-1.20.6-neoforge", 1_20_06, "mojang")
     Node mc_12101_neoforge = createNode("mc-api-1.21.1-neoforge", 1_21_01, "mojang")
     Node mc_12103_neoforge = createNode("mc-api-1.21.3-neoforge", 1_21_03, "mojang")
+    Node mc_12104_neoforge = createNode("mc-api-1.21.4-neoforge", 1_21_04, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
     mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
     mc_12101_fabric.link(mc_12101_neoforge, file("versions/mapping-1.21.1-fabric-neoforge.txt"))
     mc_12103_fabric.link(mc_12103_neoforge, file("versions/mapping-1.21.3-fabric-neoforge.txt"))
+    mc_12104_fabric.link(mc_12104_neoforge, file("versions/mapping-1.21.4-fabric-neoforge.txt"))
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/network/chat/StyleCompatImpl.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/network/chat/StyleCompatImpl.java
@@ -293,7 +293,7 @@ public class StyleCompatImpl extends AbstractCompat<Style> implements StyleCompa
         //$$             break;
         //$$         case RESET:
         //$$             this.style = new Style();
-        //$$             return this;
+        //$$             break;
         //$$         default:
         //$$             this.style.setColor(chatFormatting);
         //$$     }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/accessor/StyleAccessor.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/accessor/StyleAccessor.java
@@ -22,6 +22,9 @@ public interface StyleAccessor {
     @Invoker(value = "<init>")
     static Style magiclib$invokeConstructor(
             @Nullable TextColor color,
+            //#if MC > 12103
+            //$$ @Nullable Integer integer,
+            //#endif
             @Nullable Boolean bold,
             @Nullable Boolean italic,
             @Nullable Boolean underlined,

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/event/render/LevelRendererMixin.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/event/render/LevelRendererMixin.java
@@ -57,7 +57,9 @@ public abstract class LevelRendererMixin {
             boolean renderBlockOutline,
             Camera camera,
             GameRenderer gameRenderer,
+            //#if MC < 12104
             LightTexture lightTexture,
+            //#endif
             Matrix4f frustumMatrix,
             //#if MC > 12004
             //$$ Matrix4f projectionMatrix,
@@ -126,7 +128,9 @@ public abstract class LevelRendererMixin {
             boolean renderBlockOutline,
             Camera camera,
             GameRenderer gameRenderer,
+            //#if MC < 12104
             LightTexture lightTexture,
+            //#endif
             Matrix4f frustumMatrix,
             //#if MC > 12004
             //$$ Matrix4f projectionMatrix,

--- a/magiclib-minecraft-api/versions/1.21.4-fabric/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.4-fabric/gradle.properties
@@ -1,0 +1,7 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.4- <1.21.5-
+dependencies.minecraft_version=1.21.4
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=

--- a/magiclib-minecraft-api/versions/1.21.4-fabric/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.21.4-fabric/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/1.21.4-neoforge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.4-neoforge/gradle.properties
@@ -1,0 +1,11 @@
+# Dependency Versions
+dependencies.neoforge_version=21.4.46-beta
+dependencies.minecraft_dependency=1.21.4
+dependencies.minecraft_version=1.21.4
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21.4
+publish.dependencies_list=

--- a/magiclib-minecraft-api/versions/1.21.4-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.21.4-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/mapping-1.21.4-fabric-neoforge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.21.4-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/settings.json
+++ b/settings.json
@@ -46,7 +46,8 @@
         "1.20.4-fabric",
         "1.20.6-fabric",
         "1.21.1-fabric",
-        "1.21.3-fabric"
+        "1.21.3-fabric",
+        "1.21.4-fabric"
       ]
     },
     "magiclib-malilib-extra": {

--- a/settings.json
+++ b/settings.json
@@ -17,6 +17,7 @@
         "1.20.6-fabric",
         "1.21.1-fabric",
         "1.21.3-fabric",
+        "1.21.4-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",
@@ -25,7 +26,8 @@
         "1.20.2-neoforge",
         "1.20.6-neoforge",
         "1.21.1-neoforge",
-        "1.21.3-neoforge"
+        "1.21.3-neoforge",
+        "1.21.4-neoforge"
       ]
     },
     "magiclib-legacy-compat": {
@@ -64,13 +66,16 @@
         "1.20.6-fabric",
         "1.21.1-fabric",
         "1.21.3-fabric",
+        "1.21.4-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",
         "1.19.4-forge",
 
         "1.20.6-neoforge",
-        "1.21.1-neoforge"
+        "1.21.1-neoforge",
+        "1.21.3-neoforge",
+        "1.21.4-neoforge"
       ]
     },
     "magiclib-minecraft-api": {
@@ -90,6 +95,7 @@
         "1.20.6-fabric",
         "1.21.1-fabric",
         "1.21.3-fabric",
+        "1.21.4-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",
@@ -98,7 +104,8 @@
         "1.20.2-neoforge",
         "1.20.6-neoforge",
         "1.21.1-neoforge",
-        "1.21.3-neoforge"
+        "1.21.3-neoforge",
+        "1.21.4-neoforge"
       ]
     }
   }


### PR DESCRIPTION
MagicLib modules already basically support Minecraft 1.21.4. Passed Mixin audit.

|             | magiclib-better-dev | magiclib-legacy-compat | magiclib-minecraft-api | magiclib-malilib-extra |
|:-----------:|:-------------------:|:----------------------:|:----------------------:|:----------------------:|
|   Fabric    |          √          |           √            |           √            |           √            |
| (Neo)Forge  |          √          |    *(Unsupported)*     |           √            |           √            |

This pr also contains:

|             | magiclib-malilib-extra |
|:-----------:|:----------------------:|
| (Neo)Forge  |         1.21.3         |


