### PR TITLE
Fix magiclib-legacy-compat causing lag in cloth-config2 calls (MC 1.14)

### DIFF
--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/cloth/renderSystem/RenderHelperMixin.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/mixin/compat/cloth/renderSystem/RenderHelperMixin.java
@@ -1,0 +1,9 @@
+package top.hendrixshen.magiclib.mixin.compat.cloth.renderSystem;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import top.hendrixshen.magiclib.api.preprocess.DummyClass;
+
+@Mixin(DummyClass.class)
+public class RenderHelperMixin {
+}

--- a/magiclib-legacy-compat/src/main/resources/fabric.mod.json
+++ b/magiclib-legacy-compat/src/main/resources/fabric.mod.json
@@ -37,13 +37,11 @@
     ],
     "server": [
       "top.hendrixshen.magiclib.entrypoint.legacy.MagicLibFabric"
-    ],
-    "modmenu": [
-      "top.hendrixshen.magiclib.game.malilib.ModMenuImpl"
     ]
   },
   "mixins": [
     "${mod_id}-carpet.mixins.json",
+    "${mod_id}-cloth-config.mixins.json",
     "${mod_id}-malilib.mixins.json",
     "${mod_id}-minecraft-compat-api.mixins.json"
   ],

--- a/magiclib-legacy-compat/src/main/resources/magiclib_legacy_compat-cloth-config.mixins.json
+++ b/magiclib-legacy-compat/src/main/resources/magiclib_legacy_compat-cloth-config.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "top.hendrixshen.magiclib.mixin.compat.cloth",
+  "plugin": "top.hendrixshen.magiclib.impl.mixin.MagicMixinPlugin",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "client": [
+    "renderSystem.RenderHelperMixin"
+  ]
+}

--- a/magiclib-legacy-compat/versions/1.14.4-fabric/src/main/java/top/hendrixshen/magiclib/mixin/compat/cloth/renderSystem/RenderHelperMixin.java
+++ b/magiclib-legacy-compat/versions/1.14.4-fabric/src/main/java/top/hendrixshen/magiclib/mixin/compat/cloth/renderSystem/RenderHelperMixin.java
@@ -1,0 +1,30 @@
+package top.hendrixshen.magiclib.mixin.compat.cloth.renderSystem;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
+import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
+
+@Dependencies(require = @Dependency(value = "cloth-config2"))
+@Pseudo
+@Mixin(targets = "me.shedaniel.math.compat.RenderHelper", remap = false)
+public class RenderHelperMixin {
+    @Dynamic
+    @WrapOperation(
+            method = "<clinit>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/lang/Class;forName(Ljava/lang/String;)Ljava/lang/Class;",
+                    ordinal = 0
+            )
+    )
+    // We need to hide RenderSystem from cloth-api, which shouldn't be here.
+    private static Class<?> patchReflection(String className, Operation<Class<?>> original) throws ClassNotFoundException {
+        throw new ClassNotFoundException("com.mojang.blaze3d.systems.RenderSystem");
+    }
+}


### PR DESCRIPTION
## Summary
The RenderSystem we've added causes cloth to mistakenly think it's running MC 1.15+, which messes up some things related to reflection.