### PR TITLE
Minecraft 1.21.5 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ dependencies.lombok_version=1.18.36
 dependencies.jetbrains_annotations_version=26.0.2
 
 # Gradle Plugins
-architectury_loom_version=1.9-SNAPSHOT
+architectury_loom_version=1.10-SNAPSHOT
 checkstyle_version=10.21.1
 grgit_version=5.3.0
 preprocessor_version=9d21b33

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ mod.version=0.8
 
 # Dependency Versions
 ## Fabric Environment
-dependencies.fabric_loader_version=0.16.10
+dependencies.fabric_loader_version=0.16.13
 ## Annotation processor
 dependencies.lombok_version=1.18.36
 ## Misc

--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -61,10 +61,12 @@ preprocess {
     Node mc_12101_neoforge = createNode("better-dev-1.21.1-neoforge", 1_21_01, "mojang")
     Node mc_12103_neoforge = createNode("better-dev-1.21.3-neoforge", 1_21_03, "mojang")
     Node mc_12104_neoforge = createNode("better-dev-1.21.4-neoforge", 1_21_04, "mojang")
+    Node mc_12105_neoforge = createNode("better-dev-1.21.5-neoforge", 1_21_05, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
     mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
     mc_12101_fabric.link(mc_12101_neoforge, file("versions/mapping-1.21.1-fabric-neoforge.txt"))
     mc_12103_fabric.link(mc_12103_neoforge, file("versions/mapping-1.21.3-fabric-neoforge.txt"))
     mc_12104_fabric.link(mc_12104_neoforge, file("versions/mapping-1.21.4-fabric-neoforge.txt"))
+    mc_12105_fabric.link(mc_12105_neoforge, file("versions/mapping-1.21.5-fabric-neoforge.txt"))
 }

--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -28,6 +28,7 @@ preprocess {
     Node mc_12101_fabric = createNode("better-dev-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("better-dev-1.21.3-fabric", 1_21_03, "mojang")
     Node mc_12104_fabric = createNode("better-dev-1.21.4-fabric", 1_21_04, "mojang")
+    Node mc_12105_fabric = createNode("better-dev-1.21.5-fabric", 1_21_05, "mojang")
 
     mc_11502_fabric.link(mc_11404_fabric, file("versions/mapping-fabric-1.15.2-1.14.4.txt"))
     mc_11605_fabric.link(mc_11502_fabric, file("versions/mapping-fabric-1.16.5-1.15.2.txt"))
@@ -43,6 +44,7 @@ preprocess {
     mc_12006_fabric.link(mc_12101_fabric, file("versions/mapping-fabric-1.20.6-1.21.1.txt"))
     mc_12101_fabric.link(mc_12103_fabric, file("versions/mapping-fabric-1.21.1-1.21.3.txt"))
     mc_12103_fabric.link(mc_12104_fabric, file("versions/mapping-fabric-1.21.3-1.21.4.txt"))
+    mc_12104_fabric.link(mc_12105_fabric, file("versions/mapping-fabric-1.21.4-1.21.5.txt"))
 
     // Forge
     Node mc_11701_forge = createNode("better-dev-1.17.1-forge", 1_17_01, "mojang")

--- a/magiclib-better-dev/versions/1.20.4-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/auth/MinecraftMixin.java
+++ b/magiclib-better-dev/versions/1.20.4-fabric/src/main/java/top/hendrixshen/magiclib/mixin/dev/auth/MinecraftMixin.java
@@ -1,0 +1,9 @@
+package top.hendrixshen.magiclib.mixin.dev.auth;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import top.hendrixshen.magiclib.api.preprocess.DummyClass;
+
+@Mixin(DummyClass.class)
+public class MinecraftMixin {
+}

--- a/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
@@ -11,9 +11,9 @@ dependencies.api.modmenu_version=14.0.0-rc.2
 # IMBlockerFabric 1.0.24
 # imblockerfabric-1.0.24.jar
 dependencies.runtime.imblocker_version=1.0.24
-# In-Game Account Switcher
-# TODO
-dependencies.runtime.inGameAccountSwitcher_version=0
+# In-Game Account Switcher 9.0.2
+# IAS-Fabric-1.21.5-9.0.2.jar
+dependencies.runtime.inGameAccountSwitcher_version=96FYffnc
 
 # Publish properties
 publish.game_version=1.21.5

--- a/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
@@ -2,15 +2,15 @@
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
 dependencies.minecraft_version=1.21.5
 
-# Fabric API 0.119.5+1.21.5
-dependencies.api.fabric_version=0.119.5+1.21.5
+# Fabric API 0.119.6+1.21.5
+dependencies.api.fabric_version=0.119.6+1.21.5
 # Mod Menu 14.0.0-rc.2
 # modmenu-14.0.0-rc.2.jar
 dependencies.api.modmenu_version=14.0.0-rc.2
 
-# IMBlockerFabric
-# TODO
-dependencies.runtime.imblocker_version=0
+# IMBlockerFabric 1.0.24
+# imblockerfabric-1.0.24.jar
+dependencies.runtime.imblocker_version=1.0.24
 # In-Game Account Switcher
 # TODO
 dependencies.runtime.inGameAccountSwitcher_version=0

--- a/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
@@ -15,10 +15,6 @@ dependencies.runtime.imblocker_version=0
 # TODO
 dependencies.runtime.inGameAccountSwitcher_version=0
 
-# Loom Properties
-# TODO Arch Loom 1.10
-loom.ignoreDependencyLoomVersionValidation=true
-
 # Publish properties
 publish.game_version=1.21.5
 publish.dependencies_list=

--- a/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
@@ -1,12 +1,12 @@
 # Dependency Versions
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
-dependencies.minecraft_version=1.21.5-rc1
+dependencies.minecraft_version=1.21.5
 
-# Fabric API 0.119.2+1.21.5
-dependencies.api.fabric_version=0.119.2+1.21.5
-# Mod Menu 14.0.0-beta.2
-# modmenu-14.0.0-beta.2.jar
-dependencies.api.modmenu_version=14.0.0-beta.2
+# Fabric API 0.119.5+1.21.5
+dependencies.api.fabric_version=0.119.5+1.21.5
+# Mod Menu 14.0.0-rc.2
+# modmenu-14.0.0-rc.2.jar
+dependencies.api.modmenu_version=14.0.0-rc.2
 
 # IMBlockerFabric
 # TODO

--- a/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
@@ -1,0 +1,24 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
+dependencies.minecraft_version=1.21.5-rc1
+
+# Fabric API 0.119.2+1.21.5
+dependencies.api.fabric_version=0.119.2+1.21.5
+# Mod Menu 14.0.0-beta.2
+# modmenu-14.0.0-beta.2.jar
+dependencies.api.modmenu_version=14.0.0-beta.2
+
+# IMBlockerFabric
+# TODO
+dependencies.runtime.imblocker_version=0
+# In-Game Account Switcher
+# TODO
+dependencies.runtime.inGameAccountSwitcher_version=0
+
+# Loom Properties
+# TODO Arch Loom 1.10
+loom.ignoreDependencyLoomVersionValidation=true
+
+# Publish properties
+publish.game_version=1.21.5
+publish.dependencies_list=

--- a/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-fabric/gradle.properties
@@ -2,8 +2,8 @@
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
 dependencies.minecraft_version=1.21.5
 
-# Fabric API 0.119.6+1.21.5
-dependencies.api.fabric_version=0.119.6+1.21.5
+# Fabric API 0.119.9+1.21.5
+dependencies.api.fabric_version=0.119.9+1.21.5
 # Mod Menu 14.0.0-rc.2
 # modmenu-14.0.0-rc.2.jar
 dependencies.api.modmenu_version=14.0.0-rc.2

--- a/magiclib-better-dev/versions/1.21.5-fabric/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.21.5-fabric/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency Versions
-dependencies.neoforge_version=21.5.2-beta
+dependencies.neoforge_version=21.5.7-beta
 dependencies.minecraft_dependency=1.21.5
 dependencies.minecraft_version=1.21.5
 

--- a/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
@@ -6,9 +6,9 @@ dependencies.minecraft_version=1.21.5
 # IMBlocker
 # TODO
 dependencies.runtime.imblocker_version=0
-# In-Game Account Switcher
-# TODO
-dependencies.runtime.inGameAccountSwitcher_version=0
+# In-Game Account Switcher 9.0.2
+# IAS-NeoForge-1.21.5-9.0.2.jar
+dependencies.runtime.inGameAccountSwitcher_version=ldQRqpLN
 
 # Loom Properties
 loom.platform=neoforge

--- a/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
@@ -1,0 +1,18 @@
+# Dependency Versions
+dependencies.neoforge_version=21.5.2-beta
+dependencies.minecraft_dependency=1.21.5
+dependencies.minecraft_version=1.21.5
+
+# IMBlocker
+# TODO
+dependencies.runtime.imblocker_version=0
+# In-Game Account Switcher
+# TODO
+dependencies.runtime.inGameAccountSwitcher_version=0
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21.5
+publish.dependencies_list=

--- a/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-better-dev/versions/1.21.5-neoforge/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency Versions
-dependencies.neoforge_version=21.5.7-beta
+dependencies.neoforge_version=21.5.30-beta
 dependencies.minecraft_dependency=1.21.5
 dependencies.minecraft_version=1.21.5
 

--- a/magiclib-better-dev/versions/1.21.5-neoforge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.21.5-neoforge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/mapping-1.21.5-fabric-neoforge.txt
+++ b/magiclib-better-dev/versions/mapping-1.21.5-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-legacy-compat/build.gradle
+++ b/magiclib-legacy-compat/build.gradle
@@ -28,6 +28,7 @@ preprocess {
     Node mc_12101_fabric = createNode("legacy-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("legacy-1.21.3-fabric", 1_21_03, "mojang")
     Node mc_12104_fabric = createNode("legacy-1.21.4-fabric", 1_21_04, "mojang")
+    Node mc_12105_fabric = createNode("legacy-1.21.5-fabric", 1_21_05, "mojang")
 
     mc_11502_fabric.link(mc_11404_fabric, file("versions/mapping-1.15.2-1.14.4.txt"))
     mc_11605_fabric.link(mc_11502_fabric, file("versions/mapping-1.16.5-1.15.2.txt"))
@@ -43,4 +44,5 @@ preprocess {
     mc_12006_fabric.link(mc_12101_fabric, file("versions/mapping-1.20.6-1.21.1.txt"))
     mc_12101_fabric.link(mc_12103_fabric, file("versions/mapping-1.21.1-1.21.3.txt"))
     mc_12103_fabric.link(mc_12104_fabric, file("versions/mapping-1.21.3-1.21.4.txt"))
+    mc_12104_fabric.link(mc_12105_fabric, file("versions/mapping-1.21.4-1.21.5.txt"))
 }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/carpet/impl/WrappedSettingManager.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/carpet/impl/WrappedSettingManager.java
@@ -457,10 +457,8 @@ public class WrappedSettingManager extends SettingsManager {
                 ComponentUtil.simpleCompat(this.getTranslatedRuleName(source, ruleOption.getName()))
                         .withStyleCompat(style -> style
                                 .withBold(true)
-                                .withClickEvent(ClickEventCompat.of(ClickEvent.Action.RUN_COMMAND,
-                                        String.format("/%s %s", this.identifier, ruleOption.getName())))
-                                .withHoverEvent(HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
-                                        ComponentUtil.trCompat("magiclib.ui.hover.refresh")
+                                .withClickEvent(ClickEventCompat.runCommand(String.format("/%s %s", this.identifier, ruleOption.getName())))
+                                .withHoverEvent(HoverEventCompat.showTextCompat(ComponentUtil.trCompat("magiclib.ui.hover.refresh")
                                                 .withStyleCompat(style1 -> style1.withColor(ChatFormatting.GRAY))))));
 
         String descTranslationKey = String.format("%s.rule.%s.desc", this.identifier, ruleOption.getName());
@@ -479,10 +477,8 @@ public class WrappedSettingManager extends SettingsManager {
                         ComponentUtil.tr(String.format("%s.category.%s", this.identifier, category)),
                         ComponentUtil.simple("]")).withStyleCompat(style -> style
                         .withColor(ChatFormatting.AQUA)
-                        .withClickEvent(ClickEventCompat.of(ClickEvent.Action.RUN_COMMAND,
-                                String.format("/%s list %s", this.identifier, category)))
-                        .withHoverEvent(HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
-                                ComponentUtil.trCompat("magiclib.ui.hover.list_all_category", category)))))
+                        .withClickEvent(ClickEventCompat.runCommand(String.format("/%s list %s", this.identifier, category)))
+                        .withHoverEvent(HoverEventCompat.showTextCompat(ComponentUtil.trCompat("magiclib.ui.hover.list_all_category", category)))))
                 .collect(Collectors.toList())));
 
         if (categories.size() < 2) {
@@ -512,11 +508,9 @@ public class WrappedSettingManager extends SettingsManager {
                                         ruleOption.getDefaultStringValue().equals(option) ? ChatFormatting.DARK_GREEN :
                                                 ChatFormatting.YELLOW)
                                 .withClickEvent(ruleOption.getStringValue().equals(option) || this.locked() ? null :
-                                        ClickEventCompat.of(ClickEvent.Action.SUGGEST_COMMAND,
-                                                String.format("/%s %s %s", this.identifier, ruleOption.getName(), option)))
+                                        ClickEventCompat.suggestCommand(String.format("/%s %s %s", this.identifier, ruleOption.getName(), option)))
                                 .withHoverEvent(ruleOption.getStringValue().equals(option) || this.locked() ? null :
-                                        HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
-                                                ComponentUtil.trCompat("magiclib.ui.hover.switch_to", option)))))
+                                        HoverEventCompat.showTextCompat(ComponentUtil.trCompat("magiclib.ui.hover.switch_to", option)))))
                         .collect(Collectors.toList())),
                 ComponentUtil.simple(" ]").withStyle(style -> style.withColor(ChatFormatting.YELLOW))));
         return 1;
@@ -543,10 +537,9 @@ public class WrappedSettingManager extends SettingsManager {
                                 ComponentUtil.tr("magiclib.ui.change_permanently"),
                                 ComponentUtil.simple("]")).withStyleCompat(style -> style
                                 .withColor(ChatFormatting.AQUA)
-                                .withClickEvent(ClickEventCompat.of(ClickEvent.Action.RUN_COMMAND,
-                                        String.format("/%s setDefault %s %s",
+                                .withClickEvent(ClickEventCompat.runCommand(String.format("/%s setDefault %s %s",
                                                 this.identifier, ruleOption.getName(), newValue)))
-                                .withHoverEvent(HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
+                                .withHoverEvent(HoverEventCompat.showTextCompat(
                                         ComponentUtil.trCompat("magiclib.ui.hover.change_permanently",
                                                 String.format("%s.conf", this.identifier))))))));
         return 1;
@@ -644,8 +637,8 @@ public class WrappedSettingManager extends SettingsManager {
         for (RuleOption ruleOption : ruleOptions) {
             List<MutableComponentCompat> components = Lists.newArrayList();
             components.add(ComponentCompat.literalCompat(String.format("- %s", this.getTranslatedRuleName(ruleOption.getName()))).withStyleCompat(style -> style
-                    .withClickEvent(ClickEventCompat.of(ClickEvent.Action.RUN_COMMAND, String.format("/%s %s", this.identifier, ruleOption.getName())))
-                    .withHoverEvent(HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT, ComponentCompat.literalCompat(this.trRuleDesc(ruleOption.getName())).withStyle(style1 -> style1.withColor(ChatFormatting.YELLOW))))));
+                    .withClickEvent(ClickEventCompat.runCommand(String.format("/%s %s", this.identifier, ruleOption.getName())))
+                    .withHoverEvent(HoverEventCompat.showTextCompat(ComponentCompat.literalCompat(this.trRuleDesc(ruleOption.getName())).withStyle(style1 -> style1.withColor(ChatFormatting.YELLOW))))));
             components.add(ComponentCompat.literalCompat(" "));
             List<String> options = new ArrayList<>(ruleOption.getOptions());
 
@@ -657,8 +650,8 @@ public class WrappedSettingManager extends SettingsManager {
                 components.add(ComponentCompat.literalCompat(String.format("[%s]", option)).withStyleCompat(style ->
                         style.withUnderlined(ruleOption.getStringValue().equals(option))
                                 .withColor(ruleOption.isDefault() ? ChatFormatting.GRAY : ruleOption.getDefaultStringValue().equals(option) ? ChatFormatting.DARK_GREEN : ChatFormatting.YELLOW)
-                                .withClickEvent(ruleOption.getStringValue().equals(option) || this.locked() ? null : ClickEventCompat.of(ClickEvent.Action.SUGGEST_COMMAND, String.format("/%s %s %s", this.identifier, ruleOption.getName(), option)))
-                                .withHoverEvent(ruleOption.getStringValue().equals(option) || this.locked() ? null : HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT, ComponentCompat.literalCompat(this.trUI("hover.switch_to", option))))));
+                                .withClickEvent(ruleOption.getStringValue().equals(option) || this.locked() ? null : ClickEventCompat.suggestCommand(String.format("/%s %s %s", this.identifier, ruleOption.getName(), option)))
+                                .withHoverEvent(ruleOption.getStringValue().equals(option) || this.locked() ? null : HoverEventCompat.showTextCompat(ComponentCompat.literalCompat(this.trUI("hover.switch_to", option))))));
                 components.add(ComponentCompat.literalCompat(" "));
             }
 
@@ -678,13 +671,11 @@ public class WrappedSettingManager extends SettingsManager {
                     List<MutableComponentCompat> components = Lists.newArrayList();
                     components.add(ComponentUtil.composeCompat("- ",
                             this.getTranslatedRuleName(source, option.getName())).withStyleCompat(style -> {
-                        style.withClickEvent(ClickEventCompat.of(ClickEvent.Action.RUN_COMMAND,
-                                String.format("/%s %s", this.identifier, option.getName())));
+                        style.withClickEvent(ClickEventCompat.runCommand(String.format("/%s %s", this.identifier, option.getName())));
                         String descTranslationKey = String.format("%s.rule.%s.desc", this.identifier, option.getName());
 
                         if (I18n.exists(descTranslationKey)) {
-                            style.withHoverEvent(HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
-                                    ComponentUtil.trCompat(descTranslationKey)
+                            style.withHoverEvent(HoverEventCompat.showTextCompat(ComponentUtil.trCompat(descTranslationKey)
                                             .withStyleCompat(style1 -> style1.withColor(ChatFormatting.YELLOW))));
                         }
 
@@ -704,10 +695,9 @@ public class WrappedSettingManager extends SettingsManager {
                                             o.equals(option.getDefaultStringValue()) ? ChatFormatting.DARK_GREEN :
                                                     ChatFormatting.YELLOW)
                                     .withClickEvent(o.equals(option.getStringValue()) || this.locked() ? null :
-                                            ClickEventCompat.of(ClickEvent.Action.SUGGEST_COMMAND,
-                                                    String.format("/%s %s %s", this.identifier, option.getName(), o)))
+                                            ClickEventCompat.suggestCommand(String.format("/%s %s %s", this.identifier, option.getName(), o)))
                                     .withHoverEvent(o.equals(option.getStringValue()) || this.locked() ? null :
-                                            HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
+                                            HoverEventCompat.showTextCompat(
                                                     ComponentUtil.trCompat("magiclib.ui.hover.switch_to", o)))))
                             .collect(Collectors.toList())));
                     ret.add(ComponentUtil.joinCompat(ComponentUtil.emptyCompat(), components));
@@ -748,10 +738,8 @@ public class WrappedSettingManager extends SettingsManager {
                                 ComponentUtil.tr(String.format("%s.category.%s", this.identifier, category)),
                                 "]").withStyleCompat(style -> style
                                 .withColor(ChatFormatting.AQUA)
-                                .withClickEvent(ClickEventCompat.of(ClickEvent.Action.RUN_COMMAND,
-                                        String.format("/%s list %s", this.identifier, category)))
-                                .withHoverEvent(HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT,
-                                        ComponentUtil.trCompat("magiclib.ui.hover.list_all_category", category)))));
+                                .withClickEvent(ClickEventCompat.runCommand(String.format("/%s list %s", this.identifier, category)))
+                                .withHoverEvent(HoverEventCompat.showTextCompat(ComponentUtil.trCompat("magiclib.ui.hover.list_all_category", category)))));
                     }
                 });
 

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/event/render/impl/RenderContext.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/event/render/impl/RenderContext.java
@@ -1,13 +1,14 @@
 package top.hendrixshen.magiclib.event.render.impl;
 
 import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import com.mojang.math.Matrix4f;
 
 import lombok.Getter;
+
+import top.hendrixshen.magiclib.impl.render.context.RenderGlobal;
 
 @Environment(EnvType.CLIENT)
 public class RenderContext {
@@ -43,46 +44,44 @@ public class RenderContext {
     }
 
     public void enableDepthTest() {
-        RenderSystem.enableDepthTest();
+        RenderGlobal.enableDepthTest();
     }
 
     public void disableDepthTest() {
-        RenderSystem.disableDepthTest();
+        RenderGlobal.disableDepthTest();
     }
 
     public void depthMask(boolean mask) {
-        RenderSystem.depthMask(mask);
+        RenderGlobal.depthMask(mask);
     }
 
     public void enableBlend() {
-        RenderSystem.enableBlend();
+        RenderGlobal.enableBlend();
     }
 
+    //#if MC < 12105
     public void blendFunc(GlStateManager.SourceFactor srcFactor, GlStateManager.DestFactor dstFactor) {
-        RenderSystem.blendFunc(srcFactor, dstFactor);
+        RenderGlobal.blendFunc(srcFactor, dstFactor);
     }
+    //#endif
 
     public void color4f(float red, float green, float blue, float alpha) {
-        //#if MC > 11605
-        //$$ RenderSystem.setShaderColor(red, green, blue, alpha);
-        //#else
-        RenderSystem.color4f(red, green, blue, alpha);
-        //#endif
+        RenderGlobal.color4f(red, green, blue, alpha);
     }
 
     //#if MC < 11904
     public void enableTexture() {
-        RenderSystem.enableTexture();
+        RenderGlobal.enableTexture();
     }
     //#endif
 
     //#if MC < 11700
     public void enableAlphaTest() {
-        RenderSystem.enableAlphaTest();
+        RenderGlobal.enableAlphaTest();
     }
 
     public void disableLighting() {
-       RenderSystem.disableLighting();
+        RenderGlobal.disableLighting();
     }
     //#endif
 }

--- a/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/malilib/impl/ConfigManager.java
+++ b/magiclib-legacy-compat/src/main/java/top/hendrixshen/magiclib/malilib/impl/ConfigManager.java
@@ -147,6 +147,9 @@ public class ConfigManager implements IKeybindProvider {
      *
      * @param configClass Your configuration class.
      */
+    //#if MC > 12104
+    //$$ @SuppressWarnings("removal")
+    //#endif
     public void parseConfigClass(@NotNull Class<?> configClass) {
         for (Field field : configClass.getDeclaredFields()) {
             Config annotation = field.getAnnotation(Config.class);
@@ -220,6 +223,20 @@ public class ConfigManager implements IKeybindProvider {
 
                         ((IMagicConfigBase) config).setValueChangedFromJsonCallback(
                                 c -> setFieldValue(field, null, ((ConfigColor) c).getColor()));
+                    //#if MC > 12104
+                    //$$ } else if (configFieldObj instanceof fi.dy.masa.malilib.util.data.Color4f) {
+                    //$$     config = new MagicConfigColor(String.format("%s.config.%s", this.identifier, annotation.category()),
+                    //$$             field.getName(), ((fi.dy.masa.malilib.util.data.Color4f) configFieldObj).toHexString());
+                    //$$     option = new ConfigOption(annotation, config);
+                    //$$
+                    //$$     config.setValueChangeCallback(c -> {
+                    //$$         setFieldValue(field, null, ((ConfigColor) c).getColor());
+                    //$$         option.getValueChangeCallback().accept(option);
+                    //$$     });
+                    //$$
+                    //$$     ((IMagicConfigBase) config).setValueChangedFromJsonCallback(
+                    //$$             c -> setFieldValue(field, null, ((ConfigColor) c).getColor()));
+                    //#endif
                     } else if (configFieldObj instanceof Double) {
                         Numeric numeric = field.getAnnotation(Numeric.class);
 

--- a/magiclib-legacy-compat/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.21.5-fabric/gradle.properties
@@ -1,0 +1,13 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
+dependencies.minecraft_version=1.21.5-rc1
+
+# Carpet - 1.4.168+v250226
+# fabric-carpet-25w09a-1.4.168+v250226.jar
+dependencies.api.carpet_version=25w09a-1.4.168+v250226
+
+# Publish properties
+publish.game_version=1.21.5
+publish.dependencies_list=\
+  carpet(optional){modrinth:TQTTVgYE}{curseforge:349239}#(ignore:github),\
+  malilib(optional){modrinth:GcWjdA9I}{curseforge:303119}#(ignore:github)

--- a/magiclib-legacy-compat/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-legacy-compat/versions/1.21.5-fabric/gradle.properties
@@ -1,10 +1,10 @@
 # Dependency Versions
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
-dependencies.minecraft_version=1.21.5-rc1
+dependencies.minecraft_version=1.21.5
 
-# Carpet - 1.4.168+v250226
-# fabric-carpet-25w09a-1.4.168+v250226.jar
-dependencies.api.carpet_version=25w09a-1.4.168+v250226
+# Carpet - 1.4.169+v250325
+# fabric-carpet-1.21.5-1.4.169+v250325.jar
+dependencies.api.carpet_version=1.21.5-1.4.169+v250325
 
 # Publish properties
 publish.game_version=1.21.5

--- a/magiclib-legacy-compat/versions/1.21.5-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
+++ b/magiclib-legacy-compat/versions/1.21.5-fabric/src/main/resources/magiclib-legacy-compat.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-legacy-compat/versions/mapping-1.21.4-1.21.5.txt
+++ b/magiclib-legacy-compat/versions/mapping-1.21.4-1.21.5.txt
@@ -1,0 +1,1 @@
+com.mojang.blaze3d.platform.GlStateManager com.mojang.blaze3d.opengl.GlStateManager

--- a/magiclib-malilib-extra/build.gradle
+++ b/magiclib-malilib-extra/build.gradle
@@ -28,6 +28,7 @@ preprocess {
     Node mc_12101_fabric = createNode("malilib-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("malilib-1.21.3-fabric", 1_21_03, "mojang")
     Node mc_12104_fabric = createNode("malilib-1.21.4-fabric", 1_21_04, "mojang")
+    Node mc_12105_fabric = createNode("malilib-1.21.5-fabric", 1_21_05, "mojang")
 
     mc_11502_fabric.link(mc_11404_fabric, file("versions/mapping-fabric-1.15.2-1.14.4.txt"))
     mc_11605_fabric.link(mc_11502_fabric, file("versions/mapping-fabric-1.16.5-1.15.2.txt"))
@@ -43,6 +44,7 @@ preprocess {
     mc_12006_fabric.link(mc_12101_fabric, file("versions/mapping-fabric-1.20.6-1.21.1.txt"))
     mc_12101_fabric.link(mc_12103_fabric, file("versions/mapping-fabric-1.21.1-1.21.3.txt"))
     mc_12103_fabric.link(mc_12104_fabric, file("versions/mapping-fabric-1.21.3-1.21.4.txt"))
+    mc_12104_fabric.link(mc_12105_fabric, file("versions/mapping-fabric-1.21.4-1.21.5.txt"))
 
     // Forge
     Node mc_11701_forge = createNode("malilib-1.17.1-forge", 1_17_01, "mojang")

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/GuiVec3iTupleEdit.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/GuiVec3iTupleEdit.java
@@ -147,7 +147,13 @@ public class GuiVec3iTupleEdit extends GuiBase {
     }
 
     @Override
-    protected void drawScreenBackground(int mouseX, int mouseY) {
+    protected void drawScreenBackground(
+            //#if MC > 12104
+            //$$ GuiGraphics guiGraphics,
+            //#endif
+            int mouseX,
+            int mouseY
+    ) {
         RenderUtils.drawOutlinedBox(this.dialogLeft, this.dialogTop, this.dialogWidth, this.dialogHeight, 0xFF000000, 0xFF999999);
     }
 

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigColor.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/option/MagicConfigColor.java
@@ -2,8 +2,15 @@ package top.hendrixshen.magiclib.impl.malilib.config.option;
 
 import com.google.gson.JsonElement;
 import fi.dy.masa.malilib.config.options.ConfigColor;
-import fi.dy.masa.malilib.util.Color4f;
 import lombok.Getter;
+
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC > 12104
+//$$ import fi.dy.masa.malilib.util.data.Color4f;
+//#else
+import fi.dy.masa.malilib.util.Color4f;
+//#endif
+// CHECKSTYLE.ON: ImportOrder
 
 import top.hendrixshen.magiclib.api.malilib.config.option.MagicIConfigBase;
 

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
@@ -2,9 +2,9 @@
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
 dependencies.minecraft_version=1.21.5
 
-# Malilib 0.24.0-sakura.4
-# malilib-1.21.5-0.24.0-sakura.4
-dependencies.api.malilib_version=1.21.5-0.24.0-sakura.4
+# Malilib 0.24.0-sakura.5
+# malilib-1.21.5-0.24.0-sakura.5
+dependencies.api.malilib_version=1.21.5-0.24.0-sakura.5
 dependencies.api.malilib_version.use_sakura_fork=true
 
 # Publish properties

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
@@ -1,0 +1,13 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
+dependencies.minecraft_version=1.21.5-rc1
+
+# Malilib 0.23.999-rc1
+# malilib-1.21.5-rc1-0.23.999-rc1
+dependencies.api.malilib_version=1.21.5-rc1-0.23.999-rc1
+dependencies.api.malilib_version.use_sakura_fork=true
+
+# Publish properties
+publish.game_version=1.21.5
+publish.dependencies_list=\
+  malilib(optional){modrinth:GcWjdA9I}{curseforge:303119}#(ignore:github)

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
@@ -2,9 +2,9 @@
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
 dependencies.minecraft_version=1.21.5
 
-# Malilib 0.23.999-rc1
-# malilib-1.21.5-rc1-0.23.999-rc1
-dependencies.api.malilib_version=1.21.5-rc1-0.23.999-rc1
+# Malilib 0.24.0-sakura.3
+# malilib-1.21.5-0.24.0-sakura.3
+dependencies.api.malilib_version=1.21.5-0.24.0-sakura.3
 dependencies.api.malilib_version.use_sakura_fork=true
 
 # Publish properties

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
@@ -2,9 +2,9 @@
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
 dependencies.minecraft_version=1.21.5
 
-# Malilib 0.24.0-sakura.5
-# malilib-1.21.5-0.24.0-sakura.5
-dependencies.api.malilib_version=1.21.5-0.24.0-sakura.5
+# Malilib 0.24.0-sakura.6
+# malilib-1.21.5-0.24.0-sakura.6
+dependencies.api.malilib_version=1.21.5-0.24.0-sakura.6
 dependencies.api.malilib_version.use_sakura_fork=true
 
 # Publish properties

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency Versions
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
-dependencies.minecraft_version=1.21.5-rc1
+dependencies.minecraft_version=1.21.5
 
 # Malilib 0.23.999-rc1
 # malilib-1.21.5-rc1-0.23.999-rc1

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/gradle.properties
@@ -2,9 +2,9 @@
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
 dependencies.minecraft_version=1.21.5
 
-# Malilib 0.24.0-sakura.3
-# malilib-1.21.5-0.24.0-sakura.3
-dependencies.api.malilib_version=1.21.5-0.24.0-sakura.3
+# Malilib 0.24.0-sakura.4
+# malilib-1.21.5-0.24.0-sakura.4
+dependencies.api.malilib_version=1.21.5-0.24.0-sakura.4
 dependencies.api.malilib_version.use_sakura_fork=true
 
 # Publish properties

--- a/magiclib-malilib-extra/versions/1.21.5-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.21.5-fabric/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/mapping-fabric-1.21.4-1.21.5.txt
+++ b/magiclib-malilib-extra/versions/mapping-fabric-1.21.4-1.21.5.txt
@@ -1,0 +1,1 @@
+com.mojang.blaze3d.platform.GlStateManager com.mojang.blaze3d.opengl.GlStateManager

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -28,6 +28,7 @@ preprocess {
     Node mc_12101_fabric = createNode("mc-api-1.21.1-fabric", 1_21_01, "mojang")
     Node mc_12103_fabric = createNode("mc-api-1.21.3-fabric", 1_21_03, "mojang")
     Node mc_12104_fabric = createNode("mc-api-1.21.4-fabric", 1_21_04, "mojang")
+    Node mc_12105_fabric = createNode("mc-api-1.21.5-fabric", 1_21_05, "mojang")
 
     mc_11502_fabric.link(mc_11404_fabric, file("versions/mapping-fabric-1.15.2-1.14.4.txt"))
     mc_11605_fabric.link(mc_11502_fabric, file("versions/mapping-fabric-1.16.5-1.15.2.txt"))
@@ -43,6 +44,7 @@ preprocess {
     mc_12006_fabric.link(mc_12101_fabric, file("versions/mapping-fabric-1.20.6-1.21.1.txt"))
     mc_12101_fabric.link(mc_12103_fabric, file("versions/mapping-fabric-1.21.1-1.21.3.txt"))
     mc_12103_fabric.link(mc_12104_fabric, file("versions/mapping-fabric-1.21.3-1.21.4.txt"))
+    mc_12104_fabric.link(mc_12105_fabric, file("versions/mapping-fabric-1.21.4-1.21.5.txt"))
 
     // Forge
     Node mc_11701_forge = createNode("mc-api-1.17.1-forge", 1_17_01, "mojang")

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -61,10 +61,12 @@ preprocess {
     Node mc_12101_neoforge = createNode("mc-api-1.21.1-neoforge", 1_21_01, "mojang")
     Node mc_12103_neoforge = createNode("mc-api-1.21.3-neoforge", 1_21_03, "mojang")
     Node mc_12104_neoforge = createNode("mc-api-1.21.4-neoforge", 1_21_04, "mojang")
+    Node mc_12105_neoforge = createNode("mc-api-1.21.5-neoforge", 1_21_05, "mojang")
 
     mc_12002_fabric.link(mc_12002_neoforge, file("versions/mapping-1.20.2-fabric-neoforge.txt"))
     mc_12006_fabric.link(mc_12006_neoforge, file("versions/mapping-1.20.6-fabric-neoforge.txt"))
     mc_12101_fabric.link(mc_12101_neoforge, file("versions/mapping-1.21.1-fabric-neoforge.txt"))
     mc_12103_fabric.link(mc_12103_neoforge, file("versions/mapping-1.21.3-fabric-neoforge.txt"))
     mc_12104_fabric.link(mc_12104_neoforge, file("versions/mapping-1.21.4-fabric-neoforge.txt"))
+    mc_12105_fabric.link(mc_12105_neoforge, file("versions/mapping-1.21.5-fabric-neoforge.txt"))
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/ClickEventCompat.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/ClickEventCompat.java
@@ -2,17 +2,120 @@ package top.hendrixshen.magiclib.api.compat.minecraft.network.chat;
 
 import org.jetbrains.annotations.NotNull;
 
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC < 12105
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+//#endif
+// CHECKSTYLE.OFF: ImportOrder
+
 import net.minecraft.network.chat.ClickEvent;
+
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC > 12104
+//$$ import net.minecraft.network.chat.ClickEvent.ChangePage;
+//$$ import net.minecraft.network.chat.ClickEvent.CopyToClipboard;
+//$$ import net.minecraft.network.chat.ClickEvent.OpenFile;
+//$$ import net.minecraft.network.chat.ClickEvent.OpenUrl;
+//$$ import net.minecraft.network.chat.ClickEvent.RunCommand;
+//$$ import net.minecraft.network.chat.ClickEvent.SuggestCommand;
+//#else
+import net.minecraft.network.chat.ClickEvent.Action;
+//#endif
+// CHECKSTYLE.OFF: ImportOrder
 
 import top.hendrixshen.magiclib.impl.compat.minecraft.network.chat.ClickEventCompatImpl;
 import top.hendrixshen.magiclib.util.collect.Provider;
+
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC > 12104
+//$$ import java.net.URI;
+//#endif
+// CHECKSTYLE.OFF: ImportOrder
 
 public interface ClickEventCompat extends Provider<ClickEvent> {
     static @NotNull ClickEventCompat of(ClickEvent clickEvent) {
         return new ClickEventCompatImpl(clickEvent);
     }
 
-    static @NotNull ClickEventCompat of(ClickEvent.Action action, String string) {
+    //#if MC < 12105
+    @ScheduledForRemoval
+    @Deprecated
+    static @NotNull ClickEventCompat of(Action action, String string) {
         return ClickEventCompatImpl.of(action, string);
     }
+    //#endif
+
+    static @NotNull ClickEvent openUrl(String url) {
+        //#if MC > 12104
+        //$$ return new OpenUrl(URI.create(url));
+        //#else
+        return new ClickEvent(Action.OPEN_URL, url);
+        //#endif
+    }
+
+    static @NotNull ClickEventCompat openUrlCompat(String url) {
+        return ClickEventCompat.of(ClickEventCompat.openUrl(url));
+    }
+
+    static @NotNull ClickEvent openFile(String file) {
+        //#if MC > 12104
+        //$$ return new OpenFile(file);
+        //#else
+        return new ClickEvent(Action.OPEN_FILE, file);
+        //#endif
+    }
+
+    static @NotNull ClickEventCompat openFileCompat(String file) {
+        return ClickEventCompat.of(ClickEventCompat.openFile(file));
+    }
+
+    static @NotNull ClickEvent runCommand(String command) {
+        //#if MC > 12104
+        //$$ return new RunCommand(command);
+        //#else
+        return new ClickEvent(Action.RUN_COMMAND, command);
+        //#endif
+    }
+
+    static @NotNull ClickEventCompat runCommandCompat(String command) {
+        return ClickEventCompat.of(ClickEventCompat.runCommand(command));
+    }
+
+    static @NotNull ClickEvent suggestCommand(String command) {
+        //#if MC > 12104
+        //$$ return new SuggestCommand(command);
+        //#else
+        return new ClickEvent(Action.SUGGEST_COMMAND, command);
+        //#endif
+    }
+
+    static @NotNull ClickEventCompat suggestCommandCompat(String command) {
+        return ClickEventCompat.of(ClickEventCompat.suggestCommand(command));
+    }
+
+    static @NotNull ClickEvent changePage(String page) {
+        //#if MC > 12104
+        //$$ return new ChangePage(Integer.parseInt(page));
+        //#else
+        return new ClickEvent(Action.CHANGE_PAGE, page);
+        //#endif
+    }
+
+    static @NotNull ClickEventCompat changePageCompat(String page) {
+        return ClickEventCompat.of(ClickEventCompat.changePage(page));
+    }
+
+    //#if MC > 11404
+    static @NotNull ClickEvent copyToClipboard(String text) {
+        //#if MC > 12104
+        //$$ return new CopyToClipboard(text);
+        //#else
+        return new ClickEvent(Action.COPY_TO_CLIPBOARD, text);
+        //#endif
+    }
+
+    static @NotNull ClickEventCompat copyToClipboardCompat(String text) {
+        return ClickEventCompat.of(ClickEventCompat.copyToClipboard(text));
+    }
+    //#endif
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/ComponentCompat.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/ComponentCompat.java
@@ -32,13 +32,7 @@ public interface ComponentCompat extends Provider<Component> {
     }
 
     static @NotNull MutableComponentCompat literalCompat(String text) {
-        return MutableComponentCompat.of(
-                //#if MC > 11802
-                //$$ Component.literal(text)
-                //#else
-                new TextComponent(text)
-                //#endif
-        );
+        return MutableComponentCompat.of(ComponentCompat.literal(text));
     }
 
     static @NotNull BaseComponent translatable(String text, Object... objects) {
@@ -50,13 +44,7 @@ public interface ComponentCompat extends Provider<Component> {
     }
 
     static @NotNull MutableComponentCompat translatableCompat(String text, Object... objects) {
-        return MutableComponentCompat.of(
-                //#if MC > 11802
-                //$$ Component.translatable(text, objects)
-                //#else
-                new TranslatableComponent(text, objects)
-                //#endif
-        );
+        return MutableComponentCompat.of(ComponentCompat.translatable(text));
     }
 
     Style getStyle();

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/HoverEventCompat.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/api/compat/minecraft/network/chat/HoverEventCompat.java
@@ -2,7 +2,35 @@ package top.hendrixshen.magiclib.api.compat.minecraft.network.chat;
 
 import org.jetbrains.annotations.NotNull;
 
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC < 12105
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+//#endif
+// CHECKSTYLE.ON: ImportOrder
+
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
+
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC < 12105
+import net.minecraft.network.chat.HoverEvent.Action;
+//#endif
+// CHECKSTYLE.ON: ImportOrder
+
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC > 12104
+//$$ import net.minecraft.network.chat.HoverEvent.ShowEntity;
+//$$ import net.minecraft.network.chat.HoverEvent.ShowItem;
+//$$ import net.minecraft.network.chat.HoverEvent.ShowText;
+//$$ import net.minecraft.world.item.ItemStack;
+//#elseif MC > 11502
+import net.minecraft.network.chat.HoverEvent.ItemStackInfo;
+//#endif
+
+//#if MC > 11502
+import net.minecraft.network.chat.HoverEvent.EntityTooltipInfo;
+//#endif
+// CHECKSTYLE.ON: ImportOrder
 
 import top.hendrixshen.magiclib.impl.compat.minecraft.network.chat.HoverEventCompatImpl;
 import top.hendrixshen.magiclib.util.collect.Provider;
@@ -12,13 +40,93 @@ public interface HoverEventCompat extends Provider<HoverEvent> {
         return new HoverEventCompatImpl(hoverEvent);
     }
 
+    //#if MC < 12105
+    @ScheduledForRemoval
+    @Deprecated
     //#if MC > 11502
-    static @NotNull <T> HoverEventCompat of(HoverEvent.Action<T> action, @NotNull Provider<T> object) {
+    static @NotNull <T> HoverEventCompat of(Action<T> action, @NotNull Provider<T> object) {
         return HoverEventCompatImpl.of(action, object.get());
     }
     //#else
-    //$$ static @NotNull HoverEventCompatImpl of(HoverEvent.Action action, ComponentCompat object) {
+    //$$ static @NotNull HoverEventCompatImpl of(Action action, ComponentCompat object) {
     //$$     return new HoverEventCompatImpl(new HoverEvent(action, object.get()));
     //$$ }
     //#endif
+    //#endif
+
+    static @NotNull HoverEvent showText(Component text) {
+        //#if MC > 12104
+        //$$ return new ShowText(text);
+        //#else
+        return new HoverEvent(Action.SHOW_TEXT, text);
+        //#endif
+    }
+
+    static @NotNull HoverEventCompat showTextCompat(ComponentCompat text) {
+        return HoverEventCompat.of(HoverEventCompat.showText(text.get()));
+    }
+
+    static @NotNull HoverEvent showItem(
+            //#if MC > 12104
+            //$$ ItemStack itemStack
+            //#elseif MC > 11502
+            ItemStackInfo itemStack
+            //#else
+            //$$ Component itemStack
+            //#endif
+    ) {
+        //#if MC > 12104
+        //$$ return new ShowItem(itemStack);
+        //#else
+        return new HoverEvent(Action.SHOW_ITEM, itemStack);
+        //#endif
+    }
+
+    static @NotNull HoverEventCompat showItemCompat(
+            //#if MC > 12104
+            //$$ ItemStack itemStack
+            //#elseif MC > 11502
+            ItemStackInfo itemStack
+            //#else
+            //$$ ComponentCompat itemStack
+            //#endif
+    ) {
+        return HoverEventCompat.of(HoverEventCompat.showItem(
+                //#if MC > 11502
+                itemStack
+                //#else
+                //$$ itemStack.get()
+                //#endif
+        ));
+    }
+
+    static @NotNull HoverEvent showEntity(
+            //#if MC > 11502
+            EntityTooltipInfo entityTooltip
+            //#else
+            //$$ Component entityTooltip
+            //#endif
+    ) {
+        //#if MC > 12104
+        //$$ return new ShowEntity(entityTooltip);
+        //#else
+        return new HoverEvent(Action.SHOW_ENTITY, entityTooltip);
+        //#endif
+    }
+
+    static @NotNull HoverEventCompat showEntityCompat(
+            //#if MC > 11502
+            EntityTooltipInfo entityTooltip
+            //#else
+            //$$ ComponentCompat entityTooltip
+            //#endif
+    ) {
+        return HoverEventCompat.of(HoverEventCompat.showEntity(
+                //#if MC > 11502
+                entityTooltip
+                //#else
+                //$$ entityTooltip.get()
+                //#endif
+        ));
+    }
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/network/chat/ClickEventCompatImpl.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/network/chat/ClickEventCompatImpl.java
@@ -2,7 +2,19 @@ package top.hendrixshen.magiclib.impl.compat.minecraft.network.chat;
 
 import org.jetbrains.annotations.NotNull;
 
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC < 12105
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+//#endif
+// CHECKSTYLE.OFF: ImportOrder
+
 import net.minecraft.network.chat.ClickEvent;
+
+// CHECKSTYLE.OFF: ImportOrder
+//#if MC < 12105
+import net.minecraft.network.chat.ClickEvent.Action;
+//#endif
+// CHECKSTYLE.OFF: ImportOrder
 
 import top.hendrixshen.magiclib.api.compat.AbstractCompat;
 import top.hendrixshen.magiclib.api.compat.minecraft.network.chat.ClickEventCompat;
@@ -12,7 +24,11 @@ public class ClickEventCompatImpl extends AbstractCompat<ClickEvent> implements 
         super(type);
     }
 
-    public static @NotNull ClickEventCompatImpl of(ClickEvent.Action action, String string) {
+    //#if MC < 12105
+    @ScheduledForRemoval
+    @Deprecated
+    public static @NotNull ClickEventCompatImpl of(Action action, String string) {
         return new ClickEventCompatImpl(new ClickEvent(action, string));
     }
+    //#endif
 }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/network/chat/HoverEventCompatImpl.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/compat/minecraft/network/chat/HoverEventCompatImpl.java
@@ -2,6 +2,12 @@ package top.hendrixshen.magiclib.impl.compat.minecraft.network.chat;
 
 import org.jetbrains.annotations.NotNull;
 
+// CHECKSTYLE.OFF: ImportOrder
+//#if 12105 > MC && MC > 11502
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
+//#endif
+// CHECKSTYLE.ON: ImportOrder
+
 import net.minecraft.network.chat.HoverEvent;
 
 import top.hendrixshen.magiclib.api.compat.AbstractCompat;
@@ -12,7 +18,9 @@ public class HoverEventCompatImpl extends AbstractCompat<HoverEvent> implements 
         super(type);
     }
 
-    //#if MC > 11502
+    //#if 12105 > MC && MC > 11502
+    @ScheduledForRemoval
+    @Deprecated
     public static @NotNull <T> HoverEventCompatImpl of(HoverEvent.Action<T> action, T object) {
         return new HoverEventCompatImpl(new HoverEvent(action, object));
     }

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/i18n/minecraft/translation/MagicTranslation.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/i18n/minecraft/translation/MagicTranslation.java
@@ -167,33 +167,35 @@ public class MagicTranslation {
         // Translate hover text.
         HoverEvent hoverEvent = ((StyleAccessor) text.getStyle()).getHoverEvent();
 
-        BaseComponent oldHoverText = CommonUtil.make(() -> {
-            //#if MC > 12104
-            //$$ if (hoverEvent instanceof HoverEvent.ShowText(Component hoverEventText) && hoverEventText instanceof MutableComponent) {
-            //$$     return (MutableComponent) hoverEventText;
-            //$$ }
-            //#elseif MC > 11502
-            Object hoverEventText = hoverEvent.getValue(hoverEvent.getAction());
+        if (hoverEvent != null) {
+            BaseComponent oldHoverText = CommonUtil.make(() -> {
+                //#if MC > 12104
+                //$$ if (hoverEvent instanceof HoverEvent.ShowText(Component hoverEventText) && hoverEventText instanceof MutableComponent) {
+                //$$     return (MutableComponent) hoverEventText;
+                //$$ }
+                //#elseif MC > 11502
+                Object hoverEventText = hoverEvent.getValue(hoverEvent.getAction());
 
-            if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverEventText instanceof BaseComponent) {
-                return (BaseComponent) hoverEventText;
-            }
-            //#else
-            //$$ Component hoverEventText = hoverEvent.getValue();
-            //$$
-            //$$ if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverEventText instanceof BaseComponent) {
-            //$$     return (BaseComponent) hoverEventText;
-            //$$ }
-            //#endif
+                if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverEventText instanceof BaseComponent) {
+                    return (BaseComponent) hoverEventText;
+                }
+                //#else
+                //$$ Component hoverEventText = hoverEvent.getValue();
+                //$$
+                //$$ if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverEventText instanceof BaseComponent) {
+                //$$     return (BaseComponent) hoverEventText;
+                //$$ }
+                //#endif
 
-            return null;
-        });
+                return null;
+            });
 
-        if (oldHoverText != null) {
-            BaseComponent newHoverText = MagicTranslation.forEachTranslationComponent(oldHoverText, lang, modifier);
+            if (oldHoverText != null) {
+                BaseComponent newHoverText = MagicTranslation.forEachTranslationComponent(oldHoverText, lang, modifier);
 
-            if (newHoverText != oldHoverText) {
-                ComponentUtil.hover(text, newHoverText);
+                if (newHoverText != oldHoverText) {
+                    ComponentUtil.hover(text, newHoverText);
+                }
             }
         }
 

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/i18n/minecraft/translation/MagicTranslation.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/i18n/minecraft/translation/MagicTranslation.java
@@ -42,12 +42,13 @@ import top.hendrixshen.magiclib.api.compat.minecraft.network.chat.MutableCompone
 import top.hendrixshen.magiclib.api.fake.i18n.ServerPlayerLanguage;
 import top.hendrixshen.magiclib.api.i18n.I18n;
 import top.hendrixshen.magiclib.mixin.minecraft.accessor.StyleAccessor;
+import top.hendrixshen.magiclib.util.CommonUtil;
 import top.hendrixshen.magiclib.util.minecraft.ComponentUtil;
 
 import java.util.List;
 
 /**
- * Reference to <a href="https://github.com/TISUnion/Carpet-TIS-Addition/blob/2733a1dfa4978374e7422376486b5c291ebb1bbc/src/main/java/carpettisaddition/translations/TranslationContext.java">Carpet-TIS-Addition</a>.
+ * Reference to <a href="https://github.com/TISUnion/Carpet-TIS-Addition/blob/be45c2589ad8e6cd9063dca71920ad8a873fc050/src/main/java/carpettisaddition/translations/TISAdditionTranslations.java">Carpet-TIS-Addition</a>.
  */
 public class MagicTranslation {
     public static @NotNull MutableComponentCompat translate(MutableComponentCompat text) {
@@ -166,27 +167,34 @@ public class MagicTranslation {
         // Translate hover text.
         HoverEvent hoverEvent = ((StyleAccessor) text.getStyle()).getHoverEvent();
 
-        if (hoverEvent != null) {
-            //#if MC > 11502
-            Object hoverText = hoverEvent.getValue(hoverEvent.getAction());
+        BaseComponent oldHoverText = CommonUtil.make(() -> {
+            //#if MC > 12104
+            //$$ if (hoverEvent instanceof HoverEvent.ShowText(Component hoverEventText) && hoverEventText instanceof MutableComponent) {
+            //$$     return (MutableComponent) hoverEventText;
+            //$$ }
+            //#elseif MC > 11502
+            Object hoverEventText = hoverEvent.getValue(hoverEvent.getAction());
 
-            if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverText instanceof BaseComponent) {
-                BaseComponent newText = MagicTranslation.forEachTranslationComponent((BaseComponent) hoverText,
-                        lang, modifier);
-
-                if (newText != hoverText) {
-                    text.setStyle(text.getStyle().withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, newText)));
-                }
+            if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverEventText instanceof BaseComponent) {
+                return (BaseComponent) hoverEventText;
             }
             //#else
-            //$$ Component hoverText = hoverEvent.getValue();
-            //$$ BaseComponent newText = MagicTranslation.forEachTranslationComponent((BaseComponent) hoverText,
-            //$$         lang, modifier);
+            //$$ Component hoverEventText = hoverEvent.getValue();
             //$$
-            //$$ if (newText != hoverText) {
-            //$$     text.getStyle().setHoverEvent(new HoverEvent(hoverEvent.getAction(), newText));
+            //$$ if (hoverEvent.getAction() == HoverEvent.Action.SHOW_TEXT && hoverEventText instanceof BaseComponent) {
+            //$$     return (BaseComponent) hoverEventText;
             //$$ }
             //#endif
+
+            return null;
+        });
+
+        if (oldHoverText != null) {
+            BaseComponent newHoverText = MagicTranslation.forEachTranslationComponent(oldHoverText, lang, modifier);
+
+            if (newHoverText != oldHoverText) {
+                ComponentUtil.hover(text, newHoverText);
+            }
         }
 
         // Translate sibling texts.

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/TextRenderer.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/impl/render/TextRenderer.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
-import com.mojang.blaze3d.platform.GlStateManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -178,13 +177,7 @@ public class TextRenderer {
         //#endif
         // Enable transparent-able text rendering.
         RenderGlobal.enableBlend();
-        RenderGlobal.blendFunc(
-                //#if MC > 11404
-                GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA
-                //#else
-                //$$ GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA
-                //#endif
-        );
+        RenderGlobal.blendFuncForAlpha();
 
         for (int i = 0; i < lineNum; i++) {
             TextHolder holder = this.lines.get(i);
@@ -195,7 +188,11 @@ public class TextRenderer {
 
             while (true) {
                 MultiBufferSource.BufferSource immediate = RenderUtil.getBufferSource();
+                //#if MC > 12104
+                //$$ Matrix4f matrix4f = new Matrix4f(Transformation.identity().getMatrix());
+                //#else
                 Matrix4f matrix4f = Transformation.identity().getMatrix();
+                //#endif
                 mc.font.drawInBatch(
                         holder.text,
                         textX,

--- a/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/ComponentUtil.java
+++ b/magiclib-minecraft-api/src/main/java/top/hendrixshen/magiclib/util/minecraft/ComponentUtil.java
@@ -465,8 +465,7 @@ public class ComponentUtil {
             hoverText.append(ComponentUtil.dimension(dim));
         }
 
-        return ComponentUtil.fancy(ComponentUtil.simple(posStr), hoverText,
-                new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command));
+        return ComponentUtil.fancy(ComponentUtil.simple(posStr), hoverText, ClickEventCompat.suggestCommand(command));
     }
 
     private static @NotNull MutableComponentCompat coordinateCompat(@Nullable DimensionWrapper dim, String posStr, String command) {
@@ -523,7 +522,7 @@ public class ComponentUtil {
 
     private static @NotNull BaseComponent vector(String displayText, String detailedText) {
         return ComponentUtil.fancy(ComponentUtil.simple(displayText), ComponentUtil.simple(detailedText),
-                new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, detailedText));
+                ClickEventCompat.suggestCommand(detailedText));
     }
 
     public static @NotNull BaseComponent vector(Vec3 vec) {
@@ -556,8 +555,7 @@ public class ComponentUtil {
         BaseComponent hoverText = ComponentUtil.compose(ComponentUtil.translator.tr("entity_type",
                         entityBaseName, ComponentUtil.simple(EntityType.getKey(entity.getType()).toString())),
                 ComponentUtil.newLine(), ComponentUtil.getTeleportHint(entityDisplayName));
-        return ComponentUtil.fancy(entityDisplayName, hoverText, new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND,
-                TextUtil.tp(entity)));
+        return ComponentUtil.fancy(entityDisplayName, hoverText, ClickEventCompat.suggestCommand(TextUtil.tp(entity)));
     }
 
     public static @NotNull MutableComponentCompat entityCompat(Entity entity) {
@@ -647,7 +645,7 @@ public class ComponentUtil {
         }
         return ComponentUtil.fancy(ComponentUtil.block(blockState.getBlock()),
                 ComponentUtil.join(ComponentUtil.newLine(), hovers.toArray(new BaseComponent[0])),
-                new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, TextUtil.block(blockState)));
+                ClickEventCompat.suggestCommand(TextUtil.block(blockState)));
     }
 
     public static @NotNull MutableComponentCompat blockCompat(@NotNull BlockState blockState) {
@@ -715,11 +713,11 @@ public class ComponentUtil {
     }
 
     public static @NotNull BaseComponent hover(BaseComponent text, BaseComponent hoverText) {
-        return ComponentUtil.hover(text, new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverText));
+        return ComponentUtil.hover(text, HoverEventCompat.showText(hoverText));
     }
 
     public static @NotNull MutableComponentCompat hoverCompat(MutableComponentCompat text, MutableComponentCompat hoverText) {
-        return ComponentUtil.hoverCompat(text, HoverEventCompat.of(HoverEvent.Action.SHOW_TEXT, hoverText));
+        return ComponentUtil.hoverCompat(text, HoverEventCompat.showTextCompat(hoverText));
     }
 
     public static @NotNull BaseComponent click(@NotNull BaseComponent text, ClickEvent clickEvent) {

--- a/magiclib-minecraft-api/versions/1.14.4-fabric/src/main/java/top/hendrixshen/magiclib/impl/render/context/RenderGlobal.java
+++ b/magiclib-minecraft-api/versions/1.14.4-fabric/src/main/java/top/hendrixshen/magiclib/impl/render/context/RenderGlobal.java
@@ -24,121 +24,88 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
-
-// CHECKSTYLE.OFF: ImportOrder
-//#if MC > 11605
-//$$ import net.minecraft.client.renderer.ShaderInstance;
-//#endif
-// CHECKSTYLE.ON: ImportOrder
-
-// CHECKSTYLE.OFF: ImportOrder
-//#if MC > 11605
-//$$ import java.util.function.Supplier;
-//#endif
-// CHECKSTYLE.ON: ImportOrder
 
 /**
- * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/353b69cc3138ce0d767854c77776abe04b056369/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderGlobals.java">TweakerMore</a>.
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/348904161f9fff2fcb9aeb44dee05d8c994e8c21/versions/1.14.4/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderGlobals.java">TweakerMore</a>.
  */
-//#if 11700 > MC && MC < 11700
-@SuppressWarnings("deprecation")
-//#endif
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RenderGlobal {
-    //#if MC < 11700
     public static void disableAlphaTest() {
-        RenderSystem.disableAlphaTest();
+        GlStateManager.disableAlphaTest();
     }
 
     public static void enableAlphaTest() {
-        RenderSystem.enableAlphaTest();
+        GlStateManager.enableAlphaTest();
     }
 
     public static void disableLighting() {
-        RenderSystem.disableLighting();
+        GlStateManager.disableLighting();
     }
 
     public static void enableLighting() {
-        RenderSystem.enableLighting();
+        GlStateManager.enableLighting();
     }
-    //#endif
 
     public static void disableDepthTest() {
-        RenderSystem.disableDepthTest();
+        GlStateManager.disableDepthTest();
     }
 
     public static void enableDepthTest() {
-        RenderSystem.enableDepthTest();
+        GlStateManager.enableDepthTest();
     }
 
     public static void depthMask(boolean mask) {
-        RenderSystem.depthMask(mask);
+        GlStateManager.depthMask(mask);
     }
 
     public static void enableBlend() {
-        RenderSystem.enableBlend();
+        GlStateManager.enableBlend();
     }
 
     public static void disableBlend() {
-        RenderSystem.disableBlend();
+        GlStateManager.disableBlend();
     }
 
     public static void blendFunc(GlStateManager.SourceFactor srcFactor, GlStateManager.DestFactor dstFactor) {
-        RenderSystem.blendFunc(srcFactor, dstFactor);
+        GlStateManager.blendFunc(srcFactor, dstFactor);
     }
 
     public static void blendFuncSeparate(
             GlStateManager.SourceFactor sourceFactor, GlStateManager.DestFactor destFactor,
             GlStateManager.SourceFactor sourceFactorAlpha, GlStateManager.DestFactor destFactorAlpha
     ) {
-        RenderGlobal.blendFuncSeparate(sourceFactor.value, destFactor.value, sourceFactorAlpha.value, destFactorAlpha.value);
+        GlStateManager.blendFuncSeparate(sourceFactor, destFactor, sourceFactorAlpha, destFactorAlpha);
     }
 
     public static void blendFuncSeparate(int sourceFactor, int destFactor,
                                          int sourceFactorAlpha, int destFactorAlpha) {
-        RenderSystem.blendFuncSeparate(sourceFactor, destFactor, sourceFactorAlpha, destFactorAlpha);
+        GlStateManager.blendFuncSeparate(sourceFactor, destFactor, sourceFactorAlpha, destFactorAlpha);
     }
 
     public static void blendFuncForAlpha() {
         RenderGlobal.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
     }
 
-    //#if MC < 11904
     public static void enableTexture() {
-        RenderSystem.enableTexture();
+        GlStateManager.enableTexture();
     }
 
     public static void disableTexture() {
-        RenderSystem.disableTexture();
+        GlStateManager.disableTexture();
     }
-    //#endif
 
     public static void colorMask(boolean red, boolean green, boolean blue, boolean alpha) {
-        RenderSystem.colorMask(red, green, blue, alpha);
+        GlStateManager.colorMask(red, green, blue, alpha);
     }
 
     public static void color4f(float red, float green, float blue, float alpha) {
-        //#if MC > 11605
-        //$$ RenderSystem.setShaderColor(red, green, blue, alpha);
-        //#else
-        RenderSystem.color4f(red, green, blue, alpha);
-        //#endif
+        GlStateManager.color4f(red, green, blue, alpha);
     }
 
     public static void defaultBlendFunc() {
-        RenderSystem.defaultBlendFunc();
+        RenderGlobal.blendFuncSeparate(
+                GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO
+        );
     }
-
-    //#if MC > 11605
-    //$$ public static void setShader(Supplier<ShaderInstance> supplier) {
-    //$$     RenderSystem.setShader(
-    //#if MC > 12101
-    //$$             supplier.get()
-    //#else
-    //$$             supplier
-    //#endif
-    //$$     );
-    //$$ }
-    //#endif
 }

--- a/magiclib-minecraft-api/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.5-fabric/gradle.properties
@@ -5,7 +5,3 @@ dependencies.minecraft_version=1.21.5
 # Publish properties
 publish.game_version=1.21.5
 publish.dependencies_list=
-
-# Loom Properties
-# TODO Arch Loom 1.10
-loom.ignoreDependencyLoomVersionValidation=true

--- a/magiclib-minecraft-api/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.5-fabric/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency Versions
 dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
-dependencies.minecraft_version=1.21.5-rc1
+dependencies.minecraft_version=1.21.5
 
 # Publish properties
 publish.game_version=1.21.5

--- a/magiclib-minecraft-api/versions/1.21.5-fabric/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.5-fabric/gradle.properties
@@ -1,0 +1,11 @@
+# Dependency Versions
+dependencies.minecraft_dependency=>=1.21.5- <1.21.6-
+dependencies.minecraft_version=1.21.5-rc1
+
+# Publish properties
+publish.game_version=1.21.5
+publish.dependencies_list=
+
+# Loom Properties
+# TODO Arch Loom 1.10
+loom.ignoreDependencyLoomVersionValidation=true

--- a/magiclib-minecraft-api/versions/1.21.5-fabric/src/main/java/top/hendrixshen/magiclib/impl/render/context/RenderGlobal.java
+++ b/magiclib-minecraft-api/versions/1.21.5-fabric/src/main/java/top/hendrixshen/magiclib/impl/render/context/RenderGlobal.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2023  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.hendrixshen.magiclib.impl.render.context;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import com.mojang.blaze3d.opengl.GlConst;
+import com.mojang.blaze3d.opengl.GlStateManager;
+import com.mojang.blaze3d.platform.DestFactor;
+import com.mojang.blaze3d.platform.SourceFactor;
+import com.mojang.blaze3d.systems.RenderSystem;
+
+/**
+ * Reference to <a href="https://github.com/Fallen-Breath/tweakermore/blob/348904161f9fff2fcb9aeb44dee05d8c994e8c21/versions/1.21.5/src/main/java/me/fallenbreath/tweakermore/util/render/context/RenderGlobals.java">TweakerMore</a>.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RenderGlobal {
+    public static void disableDepthTest() {
+        GlStateManager._disableDepthTest();
+    }
+
+    public static void enableDepthTest() {
+        GlStateManager._enableDepthTest();
+    }
+
+    public static void depthMask(boolean mask) {
+        GlStateManager._depthMask(mask);
+    }
+
+    public static void enableBlend() {
+        GlStateManager._enableBlend();
+    }
+
+    public static void disableBlend() {
+        GlStateManager._disableBlend();
+    }
+
+    public static void blendFuncSeparate(
+            SourceFactor sourceFactor, DestFactor destFactor,
+            SourceFactor sourceFactorAlpha, DestFactor destFactorAlpha
+    ) {
+        RenderGlobal.blendFuncSeparate(
+                GlConst.toGl(sourceFactor), GlConst.toGl(destFactor),
+                GlConst.toGl(sourceFactorAlpha), GlConst.toGl(destFactorAlpha)
+        );
+    }
+
+    public static void blendFuncSeparate(int sourceFactor, int destFactor,
+                                         int sourceFactorAlpha, int destFactorAlpha) {
+        GlStateManager._blendFuncSeparate(sourceFactor, destFactor, sourceFactorAlpha, destFactorAlpha);
+    }
+
+    /**
+     * Blends with alpha channel.
+     * References:
+     * <li>{@link com.mojang.blaze3d.pipeline.BlendFunction#TRANSLUCENT}</li>
+     * <li>{@link com.mojang.blaze3d.opengl.GlCommandEncoder#applyPipelineState}</li>
+     */
+    public static void blendFuncForAlpha() {
+        RenderGlobal.blendFuncSeparate(
+                SourceFactor.SRC_ALPHA, DestFactor.ONE_MINUS_SRC_ALPHA,
+                SourceFactor.ONE, DestFactor.ONE_MINUS_SRC_ALPHA
+        );
+    }
+
+    public static void colorMask(boolean red, boolean green, boolean blue, boolean alpha) {
+        GlStateManager._colorMask(red, green, blue, alpha);
+    }
+
+    public static void color4f(float red, float green, float blue, float alpha) {
+        RenderSystem.setShaderColor(red, green, blue, alpha);
+    }
+
+    public static void defaultBlendFunc() {
+        RenderGlobal.blendFuncSeparate(
+                SourceFactor.SRC_ALPHA, DestFactor.ONE_MINUS_SRC_ALPHA,
+                SourceFactor.ONE, DestFactor.ZERO
+        );
+    }
+}

--- a/magiclib-minecraft-api/versions/1.21.5-fabric/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.21.5-fabric/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.5-neoforge/gradle.properties
@@ -1,0 +1,11 @@
+# Dependency Versions
+dependencies.neoforge_version=21.5.1-beta
+dependencies.minecraft_dependency=1.21.5
+dependencies.minecraft_version=1.21.5
+
+# Loom Properties
+loom.platform=neoforge
+
+# Publish properties
+publish.game_version=1.21.5
+publish.dependencies_list=

--- a/magiclib-minecraft-api/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.5-neoforge/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency Versions
-dependencies.neoforge_version=21.5.1-beta
+dependencies.neoforge_version=21.5.7-beta
 dependencies.minecraft_dependency=1.21.5
 dependencies.minecraft_version=1.21.5
 

--- a/magiclib-minecraft-api/versions/1.21.5-neoforge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.21.5-neoforge/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency Versions
-dependencies.neoforge_version=21.5.7-beta
+dependencies.neoforge_version=21.5.30-beta
 dependencies.minecraft_dependency=1.21.5
 dependencies.minecraft_version=1.21.5
 

--- a/magiclib-minecraft-api/versions/1.21.5-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.21.5-neoforge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible class net/minecraft/server/packs/FilePackResources$SharedZipFileAccess
+accessible field net/minecraft/server/packs/FilePackResources$SharedZipFileAccess file Ljava/io/File;

--- a/magiclib-minecraft-api/versions/mapping-1.21.5-fabric-neoforge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.21.5-fabric-neoforge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.neoforged.api.distmarker.Dist
+net.fabricmc.api.Environment net.neoforged.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.neoforged.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-minecraft-api/versions/mapping-fabric-1.21.4-1.21.5.txt
+++ b/magiclib-minecraft-api/versions/mapping-fabric-1.21.4-1.21.5.txt
@@ -1,0 +1,1 @@
+com.mojang.blaze3d.platform.GlStateManager com.mojang.blaze3d.opengl.GlStateManager

--- a/settings.json
+++ b/settings.json
@@ -48,7 +48,8 @@
         "1.20.6-fabric",
         "1.21.1-fabric",
         "1.21.3-fabric",
-        "1.21.4-fabric"
+        "1.21.4-fabric",
+        "1.21.5-fabric"
       ]
     },
     "magiclib-malilib-extra": {

--- a/settings.json
+++ b/settings.json
@@ -69,6 +69,7 @@
         "1.21.1-fabric",
         "1.21.3-fabric",
         "1.21.4-fabric",
+        "1.21.5-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",

--- a/settings.json
+++ b/settings.json
@@ -98,6 +98,7 @@
         "1.21.1-fabric",
         "1.21.3-fabric",
         "1.21.4-fabric",
+        "1.21.5-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",

--- a/settings.json
+++ b/settings.json
@@ -28,7 +28,8 @@
         "1.20.6-neoforge",
         "1.21.1-neoforge",
         "1.21.3-neoforge",
-        "1.21.4-neoforge"
+        "1.21.4-neoforge",
+        "1.21.5-neoforge"
       ]
     },
     "magiclib-legacy-compat": {

--- a/settings.json
+++ b/settings.json
@@ -111,7 +111,8 @@
         "1.20.6-neoforge",
         "1.21.1-neoforge",
         "1.21.3-neoforge",
-        "1.21.4-neoforge"
+        "1.21.4-neoforge",
+        "1.21.5-neoforge"
       ]
     }
   }

--- a/settings.json
+++ b/settings.json
@@ -18,6 +18,7 @@
         "1.21.1-fabric",
         "1.21.3-fabric",
         "1.21.4-fabric",
+        "1.21.5-fabric",
 
         "1.17.1-forge",
         "1.18.2-forge",


### PR DESCRIPTION
MagicLib modules already basically support Minecraft 1.21.5. Passed Mixin audit.

|             | magiclib-better-dev | magiclib-legacy-compat | magiclib-minecraft-api | magiclib-malilib-extra |
|:-----------:|:-------------------:|:----------------------:|:----------------------:|:----------------------:|
|   Fabric    |          √          |           √            |           √            |     basically[^1]      |
| (Neo)Forge  |          √          |  *(Unsupported)*[^2]   |           √            |         ×[^3]          |

[^1]: MaLiLib stable version not released yet.
[^2]: `magiclib-legacy-compat` retains compatibility for magiclib 0.7.x only, not Forge-Like platforms.
[^3]: MaFgLib not updated yet.



