### PR TITLE
Fix ConfigVec3iList and ConfigVec3iTupleList causing NPE if empty

### DIFF
--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/widget/WidgetVec3iListEditEntry.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/widget/WidgetVec3iListEditEntry.java
@@ -201,18 +201,22 @@ public class WidgetVec3iListEditEntry extends WidgetConfigOptionBase<Vec3i> {
                 // CHECKSTYLE.ON: SeparatorWrap
                 // CHECKSTYLE.ON: NoWhitespaceBefore
         );
-        this.vec3iEntry.render(
-                // CHECKSTYLE.OFF: NoWhitespaceBefore
-                // CHECKSTYLE.OFF: SeparatorWrap
-                mouseX,
-                mouseY,
-                selected
-                //#if MC > 11502
-                , poseStackOrGuiGraphics
-                //#endif
-                // CHECKSTYLE.ON: SeparatorWrap
-                // CHECKSTYLE.ON: NoWhitespaceBefore
-        );
+
+        if (this.vec3iEntry != null) {
+            this.vec3iEntry.render(
+                    // CHECKSTYLE.OFF: NoWhitespaceBefore
+                    // CHECKSTYLE.OFF: SeparatorWrap
+                    mouseX,
+                    mouseY,
+                    selected
+                    //#if MC > 11502
+                    , poseStackOrGuiGraphics
+                    //#endif
+                    // CHECKSTYLE.ON: SeparatorWrap
+                    // CHECKSTYLE.ON: NoWhitespaceBefore
+            );
+        }
+
         super.render(
                 // CHECKSTYLE.OFF: NoWhitespaceBefore
                 // CHECKSTYLE.OFF: SeparatorWrap
@@ -242,6 +246,10 @@ public class WidgetVec3iListEditEntry extends WidgetConfigOptionBase<Vec3i> {
 
     @Override
     public boolean onKeyTypedImpl(int keyCode, int scanCode, int modifiers) {
+        if (this.vec3iEntry == null) {
+            return false;
+        }
+
         return this.vec3iEntry.onKeyTypedImpl(keyCode, scanCode, modifiers);
     }
 

--- a/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/widget/WidgetVec3iTupleListEditEntry.java
+++ b/magiclib-malilib-extra/src/main/java/top/hendrixshen/magiclib/impl/malilib/config/gui/widget/WidgetVec3iTupleListEditEntry.java
@@ -211,30 +211,34 @@ public class WidgetVec3iTupleListEditEntry extends WidgetConfigOptionBase<Config
                 // CHECKSTYLE.ON: SeparatorWrap
                 // CHECKSTYLE.ON: NoWhitespaceBefore
         );
-        this.firstVec3iEntry.render(
-                // CHECKSTYLE.OFF: NoWhitespaceBefore
-                // CHECKSTYLE.OFF: SeparatorWrap
-                mouseX,
-                mouseY,
-                selected
-                //#if MC > 11502
-                , poseStackOrGuiGraphics
-                //#endif
-                // CHECKSTYLE.ON: SeparatorWrap
-                // CHECKSTYLE.ON: NoWhitespaceBefore
-        );
-        this.secondVec3iEntry.render(
-                // CHECKSTYLE.OFF: NoWhitespaceBefore
-                // CHECKSTYLE.OFF: SeparatorWrap
-                mouseX,
-                mouseY,
-                selected
-                //#if MC > 11502
-                , poseStackOrGuiGraphics
-                //#endif
-                // CHECKSTYLE.ON: SeparatorWrap
-                // CHECKSTYLE.ON: NoWhitespaceBefore
-        );
+
+        if (this.firstVec3iEntry != null && this.secondVec3iEntry != null) {
+            this.firstVec3iEntry.render(
+                    // CHECKSTYLE.OFF: NoWhitespaceBefore
+                    // CHECKSTYLE.OFF: SeparatorWrap
+                    mouseX,
+                    mouseY,
+                    selected
+                    //#if MC > 11502
+                    , poseStackOrGuiGraphics
+                    //#endif
+                    // CHECKSTYLE.ON: SeparatorWrap
+                    // CHECKSTYLE.ON: NoWhitespaceBefore
+            );
+            this.secondVec3iEntry.render(
+                    // CHECKSTYLE.OFF: NoWhitespaceBefore
+                    // CHECKSTYLE.OFF: SeparatorWrap
+                    mouseX,
+                    mouseY,
+                    selected
+                    //#if MC > 11502
+                    , poseStackOrGuiGraphics
+                    //#endif
+                    // CHECKSTYLE.ON: SeparatorWrap
+                    // CHECKSTYLE.ON: NoWhitespaceBefore
+            );
+        }
+
         super.render(
                 // CHECKSTYLE.OFF: NoWhitespaceBefore
                 // CHECKSTYLE.OFF: SeparatorWrap
@@ -265,6 +269,10 @@ public class WidgetVec3iTupleListEditEntry extends WidgetConfigOptionBase<Config
 
     @Override
     public boolean onKeyTypedImpl(int keyCode, int scanCode, int modifiers) {
+        if (this.firstVec3iEntry == null || this.secondVec3iEntry == null) {
+            return false;
+        }
+
         return this.firstVec3iEntry.onKeyTypedImpl(keyCode, scanCode, modifiers)
                 || this.secondVec3iEntry.onKeyTypedImpl(keyCode, scanCode, modifiers);
     }


### PR DESCRIPTION
## Summary
- If the configuration list is empty, opening configuration screen will cause NPE, affected types: `ConfigVec3iList`, `ConfigVec3iTupleList`
