### PR TITLE
Fix mixin mistake (MC 1.20.2-MC 1.20.4)

### DIFF
--- a/magiclib-minecraft-api/versions/1.20.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/network/register/ClientboundCustomPayloadPacketMixin.java
+++ b/magiclib-minecraft-api/versions/1.20.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/network/register/ClientboundCustomPayloadPacketMixin.java
@@ -32,7 +32,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import top.hendrixshen.magiclib.impl.network.packet.MagicCustomPayload;
@@ -52,7 +52,7 @@ public abstract class ClientboundCustomPayloadPacketMixin {
     @Final
     private static Map<ResourceLocation, FriendlyByteBuf.Reader<? extends CustomPacketPayload>> KNOWN_TYPES;
 
-    @ModifyArg(method = "<clinit>", at = @At(value = "RETURN"))
+    @Inject(method = "<clinit>", at = @At("RETURN"))
     private static void registerServerboundMagicPayload(CallbackInfo ci) {
         MagicPacketRegistrationCenterHelper.collectClientbound();
         ImmutableMap.Builder<ResourceLocation, FriendlyByteBuf.Reader<? extends CustomPacketPayload>> builder = ImmutableMap

--- a/magiclib-minecraft-api/versions/1.20.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/network/register/ServerboundCustomPayloadPacketMixin.java
+++ b/magiclib-minecraft-api/versions/1.20.2-fabric/src/main/java/top/hendrixshen/magiclib/mixin/minecraft/network/register/ServerboundCustomPayloadPacketMixin.java
@@ -32,7 +32,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import top.hendrixshen.magiclib.impl.network.packet.MagicCustomPayload;
@@ -52,7 +52,7 @@ public abstract class ServerboundCustomPayloadPacketMixin {
     @Final
     private static Map<ResourceLocation, FriendlyByteBuf.Reader<? extends CustomPacketPayload>> KNOWN_TYPES;
 
-    @ModifyArg(method = "<clinit>", at = @At(value = "RETURN"))
+    @Inject(method = "<clinit>", at = @At("RETURN"))
     private static void registerServerboundMagicPayload(CallbackInfo ci) {
         MagicPacketRegistrationCenterHelper.collectServerbound();
         ImmutableMap.Builder<ResourceLocation, FriendlyByteBuf.Reader<? extends CustomPacketPayload>> builder = ImmutableMap


### PR DESCRIPTION
## Summary
A mixin injection mistake causes MC crashing in #195 introduced features.