### PR TITLE
Minecraft 1.20.1 Support (Forge)

### DIFF
--- a/gradle/forges.versions.toml
+++ b/gradle/forges.versions.toml
@@ -2,6 +2,7 @@
 forge-mc11701 = "1.17.1-37.1.1"
 forge-mc11802 = "1.18.2-40.3.11"
 forge-mc11904 = "1.19.4-45.4.2"
+forge-mc12001 = "1.20.1-47.4.8"
 
 neoforge-mc12002 = "20.2.93"
 neoforge-mc12006 = "20.6.138"
@@ -15,6 +16,7 @@ neoforge-mc12108 = "21.8.31"
 forge-mc11701 = { module = "net.minecraftforge:forge", version.ref = "forge-mc11701" }
 forge-mc11802 = { module = "net.minecraftforge:forge", version.ref = "forge-mc11802" }
 forge-mc11904 = { module = "net.minecraftforge:forge", version.ref = "forge-mc11904" }
+forge-mc12001 = { module = "net.minecraftforge:forge", version.ref = "forge-mc12001" }
 
 neoforge-mc12002 = { module = "net.neoforged:neoforge", version.ref = "neoforge-mc12002" }
 neoforge-mc12006 = { module = "net.neoforged:neoforge", version.ref = "neoforge-mc12006" }

--- a/gradle/mods.versions.toml
+++ b/gradle/mods.versions.toml
@@ -102,6 +102,7 @@ malilib-mc12108 = "0.25.4"
 mafglib-mc11701 = "0.1.6-mc1.17.1"
 mafglib-mc11802 = "0.1.14-mc1.18.2"
 mafglib-mc11904 = "0.1.11-mc1.19.4"
+mafglib-mc12001 = "0.1.14-mc1.20.1"
 mafglib-mc12006 = "0.1.15-mc1.20.6"
 mafglib-mc12101 = "0.3.6-mc1.21.1"
 mafglib-mc12103 = "0.3.3-mc1.21.3"
@@ -216,6 +217,7 @@ malilib-mc12108 = { module = "maven.modrinth:malilib", version.ref = "malilib-mc
 mafglib-mc11701 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc11701" }
 mafglib-mc11802 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc11802" }
 mafglib-mc11904 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc11904" }
+mafglib-mc12001 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc12001" }
 mafglib-mc12006 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc12006" }
 mafglib-mc12101 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc12101" }
 mafglib-mc12103 = { module = "maven.modrinth:mafglib", version.ref = "mafglib-mc12103" }

--- a/gradle/mods.versions.toml
+++ b/gradle/mods.versions.toml
@@ -20,6 +20,7 @@ fabric-mc12108 = "0.131.0+1.21.8"
 imblocker-original-forge-mc11701 = "bJY9G53S"
 imblocker-original-forge-mc11802 = "bJY9G53S"
 imblocker-original-forge-mc11904 = "bJY9G53S"
+imblocker-original-forge-mc12001 = "vqhzTeuW"
 
 imblocker-original-neoforge-mc12002 = "5.0.0"
 imblocker-original-neoforge-mc12006 = "BZem119r"
@@ -50,6 +51,7 @@ in-game-account-switcher-fabric-mc12108 = "9.0.5"
 in-game-account-switcher-forge-mc11701 = "8.0.1-forge1.17"
 in-game-account-switcher-forge-mc11802 = "Az6PjZ5q"
 in-game-account-switcher-forge-mc11904 = "oGKy0OfP"
+in-game-account-switcher-forge-mc12001 = "DCMEYBKC"
 
 in-game-account-switcher-neoforge-mc12002 = "6Vr5XdM2"
 in-game-account-switcher-neoforge-mc12006 = "5AbTaqq3"
@@ -132,6 +134,7 @@ imblocker = "maven.modrinth:imblocker:1.0.24"
 imblocker-original-forge-mc11701 = { module = "maven.modrinth:imblocker-original", version.ref = "imblocker-original-forge-mc11701" }
 imblocker-original-forge-mc11802 = { module = "maven.modrinth:imblocker-original", version.ref = "imblocker-original-forge-mc11802" }
 imblocker-original-forge-mc11904 = { module = "maven.modrinth:imblocker-original", version.ref = "imblocker-original-forge-mc11904" }
+imblocker-original-forge-mc12001 = { module = "maven.modrinth:imblocker-original", version.ref = "imblocker-original-forge-mc12001" }
 
 imblocker-original-neoforge-mc12002 = { module = "maven.modrinth:imblocker-original", version.ref = "imblocker-original-neoforge-mc12002" }
 imblocker-original-neoforge-mc12006 = { module = "maven.modrinth:imblocker-original", version.ref = "imblocker-original-neoforge-mc12006" }
@@ -162,6 +165,7 @@ in-game-account-switcher-fabric-mc12108 = { module = "maven.modrinth:in-game-acc
 in-game-account-switcher-forge-mc11701 = { module = "maven.modrinth:in-game-account-switcher", version.ref = "in-game-account-switcher-forge-mc11701" }
 in-game-account-switcher-forge-mc11802 = { module = "maven.modrinth:in-game-account-switcher", version.ref = "in-game-account-switcher-forge-mc11802" }
 in-game-account-switcher-forge-mc11904 = { module = "maven.modrinth:in-game-account-switcher", version.ref = "in-game-account-switcher-forge-mc11904" }
+in-game-account-switcher-forge-mc12001 = { module = "maven.modrinth:in-game-account-switcher", version.ref = "in-game-account-switcher-forge-mc12001" }
 
 in-game-account-switcher-neoforge-mc12002 = { module = "maven.modrinth:in-game-account-switcher", version.ref = "in-game-account-switcher-neoforge-mc12002" }
 in-game-account-switcher-neoforge-mc12006 = { module = "maven.modrinth:in-game-account-switcher", version.ref = "in-game-account-switcher-neoforge-mc12006" }

--- a/magiclib-better-dev/build.gradle
+++ b/magiclib-better-dev/build.gradle
@@ -51,10 +51,12 @@ preprocess {
     Node mc_11701_forge = createNode("better-dev-1.17.1-forge", 1_17_01, "mojang")
     Node mc_11802_forge = createNode("better-dev-1.18.2-forge", 1_18_02, "mojang")
     Node mc_11904_forge = createNode("better-dev-1.19.4-forge", 1_19_04, "mojang")
+    Node mc_12001_forge = createNode("better-dev-1.20.1-forge", 1_20_01, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, file("versions/mapping-1.17.1-fabric-forge.txt"))
     mc_11802_fabric.link(mc_11802_forge, file("versions/mapping-1.18.2-fabric-forge.txt"))
     mc_11904_fabric.link(mc_11904_forge, file("versions/mapping-1.19.4-fabric-forge.txt"))
+    mc_12001_fabric.link(mc_12001_forge, file("versions/mapping-1.20.1-fabric-forge.txt"))
 
     // NeoForge
     Node mc_12002_neoforge = createNode("better-dev-1.20.2-neoforge", 1_20_02, "mojang")

--- a/magiclib-better-dev/versions/1.20.1-forge/gradle.properties
+++ b/magiclib-better-dev/versions/1.20.1-forge/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.minecraft_dependency=1.20.1
+dependencies.minecraft_version=1.20.1
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.20.1
+publish.dependencies_list=

--- a/magiclib-better-dev/versions/1.20.1-forge/src/main/resources/magiclib-better-dev.accesswidener
+++ b/magiclib-better-dev/versions/1.20.1-forge/src/main/resources/magiclib-better-dev.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-better-dev/versions/mapping-1.20.1-fabric-forge.txt
+++ b/magiclib-better-dev/versions/mapping-1.20.1-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-malilib-extra/build.gradle
+++ b/magiclib-malilib-extra/build.gradle
@@ -51,10 +51,12 @@ preprocess {
     Node mc_11701_forge = createNode("malilib-1.17.1-forge", 1_17_01, "mojang")
     Node mc_11802_forge = createNode("malilib-1.18.2-forge", 1_18_02, "mojang")
     Node mc_11904_forge = createNode("malilib-1.19.4-forge", 1_19_04, "mojang")
+    Node mc_12001_forge = createNode("malilib-1.20.1-forge", 1_20_01, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, file("versions/mapping-1.17.1-fabric-forge.txt"))
     mc_11802_fabric.link(mc_11802_forge, file("versions/mapping-1.18.2-fabric-forge.txt"))
     mc_11904_fabric.link(mc_11904_forge, file("versions/mapping-1.19.4-fabric-forge.txt"))
+    mc_12001_fabric.link(mc_12001_forge, file("versions/mapping-1.20.1-fabric-forge.txt"))
 
     // NeoForge
     Node mc_12006_neoforge = createNode("malilib-1.20.6-neoforge", 1_20_06, "mojang")

--- a/magiclib-malilib-extra/versions/1.20.1-forge/gradle.properties
+++ b/magiclib-malilib-extra/versions/1.20.1-forge/gradle.properties
@@ -1,0 +1,11 @@
+# Dependency Versions
+dependencies.minecraft_dependency=1.20.1
+dependencies.minecraft_version=1.20.1
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.20.1
+publish.dependencies_list=\
+  mafglib(optional){modrinth:SKI34J7B}{curseforge:910766}#(ignore:github)

--- a/magiclib-malilib-extra/versions/1.20.1-forge/src/main/resources/magiclib-malilib-extra.accesswidener
+++ b/magiclib-malilib-extra/versions/1.20.1-forge/src/main/resources/magiclib-malilib-extra.accesswidener
@@ -1,0 +1,1 @@
+accessWidener	v2	named

--- a/magiclib-malilib-extra/versions/mapping-1.20.1-fabric-forge.txt
+++ b/magiclib-malilib-extra/versions/mapping-1.20.1-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/magiclib-minecraft-api/build.gradle
+++ b/magiclib-minecraft-api/build.gradle
@@ -51,10 +51,12 @@ preprocess {
     Node mc_11701_forge = createNode("mc-api-1.17.1-forge", 1_17_01, "mojang")
     Node mc_11802_forge = createNode("mc-api-1.18.2-forge", 1_18_02, "mojang")
     Node mc_11904_forge = createNode("mc-api-1.19.4-forge", 1_19_04, "mojang")
+    Node mc_12001_forge = createNode("mc-api-1.20.1-forge", 1_20_01, "mojang")
 
     mc_11701_fabric.link(mc_11701_forge, file("versions/mapping-1.17.1-fabric-forge.txt"))
     mc_11802_fabric.link(mc_11802_forge, file("versions/mapping-1.18.2-fabric-forge.txt"))
     mc_11904_fabric.link(mc_11904_forge, file("versions/mapping-1.19.4-fabric-forge.txt"))
+    mc_12001_fabric.link(mc_12001_forge, file("versions/mapping-1.20.1-fabric-forge.txt"))
 
     // NeoForge
     Node mc_12002_neoforge = createNode("mc-api-1.20.2-neoforge", 1_20_02, "mojang")

--- a/magiclib-minecraft-api/versions/1.20.1-forge/gradle.properties
+++ b/magiclib-minecraft-api/versions/1.20.1-forge/gradle.properties
@@ -1,0 +1,10 @@
+# Dependency Versions
+dependencies.minecraft_dependency=1.20.1
+dependencies.minecraft_version=1.20.1
+
+# Loom Properties
+loom.platform=forge
+
+# Publish properties
+publish.game_version=1.20.1
+publish.dependencies_list=

--- a/magiclib-minecraft-api/versions/1.20.1-forge/src/main/resources/magiclib-minecraft-api.accesswidener
+++ b/magiclib-minecraft-api/versions/1.20.1-forge/src/main/resources/magiclib-minecraft-api.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	named
+accessible method net/minecraft/client/gui/screens/Screen addRenderableWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;
+accessible method net/minecraft/client/gui/screens/Screen addWidget (Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;

--- a/magiclib-minecraft-api/versions/mapping-1.20.1-fabric-forge.txt
+++ b/magiclib-minecraft-api/versions/mapping-1.20.1-fabric-forge.txt
@@ -1,0 +1,3 @@
+net.fabricmc.api.EnvType net.minecraftforge.api.distmarker.Dist
+net.fabricmc.api.Environment net.minecraftforge.api.distmarker.OnlyIn
+net.fabricmc.api.EnvType SERVER net.minecraftforge.api.distmarker.Dist DEDICATED_SERVER

--- a/settings.json
+++ b/settings.json
@@ -24,6 +24,7 @@
         "1.17.1-forge",
         "1.18.2-forge",
         "1.19.4-forge",
+        "1.20.1-forge",
 
         "1.20.2-neoforge",
         "1.20.6-neoforge",

--- a/settings.json
+++ b/settings.json
@@ -114,6 +114,7 @@
         "1.17.1-forge",
         "1.18.2-forge",
         "1.19.4-forge",
+        "1.20.1-forge",
 
         "1.20.2-neoforge",
         "1.20.6-neoforge",

--- a/settings.json
+++ b/settings.json
@@ -81,6 +81,7 @@
         "1.17.1-forge",
         "1.18.2-forge",
         "1.19.4-forge",
+        "1.20.1-forge",
 
         "1.20.6-neoforge",
         "1.21.1-neoforge",


### PR DESCRIPTION
## Summary

Minecraft Forge 1.20.1 still popular, so consider adding support.