### PR TITLE
Fix crashes

### DIFF
--- a/magiclib-better-dev/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.16.5-fabric/build.gradle
@@ -128,6 +128,10 @@ loom {
         isEnabled.set(false)
     }
 
+    mixin {
+        useLegacyMixinAp.set(true)
+    }
+
     if (modPlatform == "forge") {
         forge {
             convertAccessWideners.set(true)

--- a/magiclib-better-dev/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-better-dev/versions/1.16.5-fabric/build.gradle
@@ -128,8 +128,10 @@ loom {
         isEnabled.set(false)
     }
 
-    mixin {
-        useLegacyMixinAp.set(true)
+    if (fabricLike) {
+        mixin {
+            useLegacyMixinAp.set(true)
+        }
     }
 
     if (modPlatform == "forge") {

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/i18n/LanguageProvider.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/api/i18n/LanguageProvider.java
@@ -1,5 +1,9 @@
 package top.hendrixshen.magiclib.api.i18n;
 
+import top.hendrixshen.magiclib.MagicLib;
+import top.hendrixshen.magiclib.api.platform.PlatformType;
+import top.hendrixshen.magiclib.util.VersionUtil;
+
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -15,4 +19,14 @@ public interface LanguageProvider {
     void loadLanguage(String languageCode);
 
     Map<String, String> getLanguage(String languageCode);
+
+    default ClassLoader getClassLoader() {
+        if (VersionUtil.isVersionSatisfyPredicate(MagicLib.getInstance().getCurrentPlatform()
+                .getModVersion("minecraft"), ">=1.21.9-")
+                && MagicLib.getInstance().getCurrentPlatform().getPlatformType().matches(PlatformType.NEOFORGE)) {
+            return ClassLoader.getSystemClassLoader();
+        }
+
+        return this.getClass().getClassLoader();
+    }
 }

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/FileLanguageProvider.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/FileLanguageProvider.java
@@ -38,7 +38,7 @@ public class FileLanguageProvider implements LanguageProvider {
     @Override
     public void init() {
         try {
-            for (URL resource : Collections.list(this.getClass().getClassLoader().getResources("assets"))) {
+            for (URL resource : Collections.list(this.getClassLoader().getResources("assets"))) {
                 if (!resource.getProtocol().equals("file") && !resource.getProtocol().equals("union")) {
                     continue;
                 }

--- a/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/JarLanguageProvider.java
+++ b/magiclib-core/common/src/main/java/top/hendrixshen/magiclib/impl/i18n/provider/JarLanguageProvider.java
@@ -32,7 +32,7 @@ public class JarLanguageProvider implements LanguageProvider {
     @Override
     public void init() {
         try {
-            for (URL resource : Collections.list(ClassLoader.getSystemClassLoader().getResources("assets"))) {
+            for (URL resource : Collections.list(this.getClassLoader().getResources("assets"))) {
                 if (!resource.getProtocol().equals("jar")) {
                     continue;
                 }

--- a/magiclib-legacy-compat/src/main/resources/magiclib_legacy_compat-malilib.mixins.json
+++ b/magiclib-legacy-compat/src/main/resources/magiclib_legacy_compat-malilib.mixins.json
@@ -10,7 +10,6 @@
   "client": [
     "MixinWidgetConfigOptionForBooleanHotkeyed",
     "MixinWidgetConfigOptionForHotkeyed",
-    "accessor.KeybindMultiAccessor",
     "backport.MixinConfigBooleanHotkeyed",
     "backport.MixinWidgetConfigOptionForBooleanHotkeyed"
   ]

--- a/magiclib-legacy-compat/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.16.5-fabric/build.gradle
@@ -151,6 +151,10 @@ loom {
         enableDependencyInterfaceInjection.set(false)
     }
 
+    mixin {
+        useLegacyMixinAp.set(true)
+    }
+
     if (modPlatform == "forge") {
         forge {
             convertAccessWideners.set(true)

--- a/magiclib-legacy-compat/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-legacy-compat/versions/1.16.5-fabric/build.gradle
@@ -151,8 +151,10 @@ loom {
         enableDependencyInterfaceInjection.set(false)
     }
 
-    mixin {
-        useLegacyMixinAp.set(true)
+    if (fabricLike) {
+        mixin {
+            useLegacyMixinAp.set(true)
+        }
     }
 
     if (modPlatform == "forge") {

--- a/magiclib-malilib-extra/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.16.5-fabric/build.gradle
@@ -149,8 +149,10 @@ loom {
         isEnabled.set(false)
     }
 
-    mixin {
-        useLegacyMixinAp.set(true)
+    if (fabricLike) {
+        mixin {
+            useLegacyMixinAp.set(true)
+        }
     }
 
     if (modPlatform == "forge") {

--- a/magiclib-malilib-extra/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-malilib-extra/versions/1.16.5-fabric/build.gradle
@@ -149,6 +149,10 @@ loom {
         isEnabled.set(false)
     }
 
+    mixin {
+        useLegacyMixinAp.set(true)
+    }
+
     if (modPlatform == "forge") {
         forge {
             convertAccessWideners.set(true)

--- a/magiclib-minecraft-api/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-minecraft-api/versions/1.16.5-fabric/build.gradle
@@ -110,6 +110,10 @@ loom {
         isEnabled.set(false)
     }
 
+    mixin {
+        useLegacyMixinAp.set(true)
+    }
+
     if (modPlatform == "forge") {
         forge {
             convertAccessWideners.set(true)

--- a/magiclib-minecraft-api/versions/1.16.5-fabric/build.gradle
+++ b/magiclib-minecraft-api/versions/1.16.5-fabric/build.gradle
@@ -110,8 +110,10 @@ loom {
         isEnabled.set(false)
     }
 
-    mixin {
-        useLegacyMixinAp.set(true)
+    if (fabricLike) {
+        mixin {
+            useLegacyMixinAp.set(true)
+        }
     }
 
     if (modPlatform == "forge") {

--- a/magiclib-wrapper/fabric/build.gradle
+++ b/magiclib-wrapper/fabric/build.gradle
@@ -23,6 +23,7 @@ jar {
 
 tasks.register("copyPublishModule", Copy.class) { Copy copyTask ->
     copyTask.setGroup("${project.property("mod.id")}")
+    delete(project.layout.buildDirectory.file("tmp/submods/publish"))
 
     from {
         coreProject.tasks.shadowJar.outputs.files
@@ -196,6 +197,7 @@ subprojects {
     tasks.register("copyPublishModule", Copy.class) { Copy copyTask ->
         copyTask.dependsOn(submodules.collect { it.tasks.remapJar })
         copyTask.setGroup("${project.property("mod.id")}")
+        delete(project.layout.buildDirectory.file("tmp/submods/publish"))
 
         from {
             submodules_publish.collect {
@@ -209,6 +211,7 @@ subprojects {
     tasks.register("copyUnpublishModule", Copy.class) { Copy copyTask ->
         copyTask.dependsOn(submodules.collect { it.tasks.remapJar })
         copyTask.setGroup("${project.property("mod.id")}")
+        delete(project.layout.buildDirectory.file("tmp/submods/unpublish"))
 
         from {
             submodules_unpublish.collect {

--- a/magiclib-wrapper/forge/build.gradle
+++ b/magiclib-wrapper/forge/build.gradle
@@ -39,6 +39,9 @@ jar {
 
 tasks.register("copyPublishModule", Copy.class) { Copy copyTask ->
     copyTask.setGroup("${project.property("mod.id")}")
+    dependencies {
+        from(project.layout.buildDirectory.file("tmp/submods/publish/${project.name}.jar"))
+    }
 
     from {
         coreProject.tasks.shadowJar.outputs.files
@@ -239,6 +242,7 @@ subprojects {
     tasks.register("copyPublishModule", Copy.class) { Copy copyTask ->
         copyTask.dependsOn(submodules.collect { it.tasks.remapJar })
         copyTask.setGroup("${project.property("mod.id")}")
+        delete(project.layout.buildDirectory.file("tmp/submods/publish"))
 
         from {
             submodules_publish.collect {
@@ -252,6 +256,7 @@ subprojects {
     tasks.register("copyUnpublishModule", Copy.class) { Copy copyTask ->
         copyTask.dependsOn(submodules.collect { it.tasks.remapJar })
         copyTask.setGroup("${project.property("mod.id")}")
+        delete(project.layout.buildDirectory.file("tmp/submods/unpublish"))
 
         from {
             submodules_unpublish.collect {

--- a/magiclib-wrapper/neoforge/build.gradle
+++ b/magiclib-wrapper/neoforge/build.gradle
@@ -39,6 +39,7 @@ jar {
 
 tasks.register("copyPublishModule", Copy.class) { Copy copyTask ->
     copyTask.setGroup("${project.property("mod.id")}")
+    delete(project.layout.buildDirectory.file("tmp/submods/publish"))
 
     from {
         coreProject.tasks.shadowJar.outputs.files
@@ -245,6 +246,7 @@ subprojects {
     tasks.register("copyPublishModule", Copy.class) { Copy copyTask ->
         copyTask.dependsOn(submodules.collect { it.tasks.remapJar })
         copyTask.setGroup("${project.property("mod.id")}")
+        delete(project.layout.buildDirectory.file("tmp/submods/publish"))
 
         from {
             submodules_publish.collect {
@@ -258,6 +260,7 @@ subprojects {
     tasks.register("copyUnpublishModule", Copy.class) { Copy copyTask ->
         copyTask.dependsOn(submodules.collect { it.tasks.remapJar })
         copyTask.setGroup("${project.property("mod.id")}")
+        delete(project.layout.buildDirectory.file("tmp/submods/unpublish"))
 
         from {
             submodules_unpublish.collect {


### PR DESCRIPTION
## Summary
- Despite upgrading to Loom 1.13, the fabric mod still uses the LegacyMixinAp.
- Fix crash occurring when Malilib is not installed (#281)
- Resolved potential build issues caused by uncleared caches
- Fixed MagicI18n using incorrect classloader